### PR TITLE
Use APH neoscan block explorer instances

### DIFF
--- a/src/renderer/components/dashboard/Send.vue
+++ b/src/renderer/components/dashboard/Send.vue
@@ -34,7 +34,7 @@
           </div>
         </div>
       </div>
-      <div class="waiting" v-if="$store.state.sendInProgress === true">Waiting for transaction to appear on 3rd party block explorer....</div>
+      <div class="waiting" v-if="$store.state.sendInProgress === true">Waiting for transaction to appear on block explorer....</div>
       <div class="footer">
         <button class="back-btn" @click="showConfirmation = false" :disabled="sending">Back</button>
         <button class="send-btn" @click="send()" :disabled="sending">{{ sendButtonLabel }}</button>

--- a/src/renderer/services/neo.js
+++ b/src/renderer/services/neo.js
@@ -833,7 +833,7 @@ export default {
           const interval = setInterval(() => {
             if (moment().utc().diff(startedMonitoring, 'milliseconds') > timeouts.MONITOR_TRANSACTIONS) {
               clearInterval(interval);
-              reject('Timed out waiting for transaction to be returned from third party block explorer');
+              reject('Timed out waiting for transaction to be returned from block explorer');
               return;
             }
 

--- a/src/renderer/services/neo.js
+++ b/src/renderer/services/neo.js
@@ -290,11 +290,11 @@ export default {
 
     return new Promise((resolve, reject) => {
       try {
-        return api.loadBalance(api.getTransactionHistoryFrom, {
+        return api.getTransactionHistoryFrom({
           address,
           net: currentNetwork.net,
           url: currentNetwork.rpc,
-        })
+        }, api.neoscan)
           .then((res) => {
             resolve(res);
           })
@@ -423,12 +423,12 @@ export default {
                 return;
               }
               if (h.symbol === 'NEO') {
-                promises.push(api.loadBalance(api.getMaxClaimAmountFrom, {
+                promises.push(api.getMaxClaimAmountFrom({
                   net: currentNetwork.net,
                   url: currentNetwork.rpc,
                   address: currentWallet.address,
                   privateKey: currentWallet.privateKey,
-                })
+                }, api.neoscan)
                   .then((res) => {
                     h.availableToClaim = toBigNumber(res);
                   })
@@ -750,11 +750,11 @@ export default {
       intentAmounts.GAS = gasAmount;
     }
 
-    return api.loadBalance(api.getBalanceFrom, {
+    return api.getBalanceFrom({
       net: currentNetwork.net,
       url: currentNetwork.rpc,
       address: currentWallet.address,
-    })
+    }, api.neoscan)
     // maybe we should stand up our own version ?
       .then((balance) => {
         if (balance.net !== currentNetwork.net) {
@@ -933,12 +933,12 @@ export default {
       config.signingFunction = ledger.signWithLedger;
     }
 
-    api.loadBalance(api.getMaxClaimAmountFrom, {
+    api.getMaxClaimAmountFrom({
       net: network.getSelectedNetwork().net,
       url: currentNetwork.rpc,
       address: wallets.getCurrentWallet().address,
       privateKey: wallets.getCurrentWallet().privateKey,
-    })
+    }, api.neoscan)
       .then((res) => {
         gasClaim.gasClaimAmount = toBigNumber(res);
         gasClaim.step = 3;

--- a/src/renderer/services/network.js
+++ b/src/renderer/services/network.js
@@ -41,10 +41,17 @@ export default {
   },
 
   init() {
-    settings.networks.MainNet.extra.neoscan = 'https://explorer.aphelion-neo.com:4443/api/main_net';
-    settings.networks.TestNet.extra.neoscan = 'https://test-explorer.aphelion-neo.com:4443/api/test_net';
-
     this.setSelectedNetwork(this.getSelectedNetwork());
+  },
+
+  setExplorer(useAphExplorer) {
+    if (useAphExplorer === true) {
+      settings.networks.MainNet.extra.neoscan = 'https://explorer.aphelion-neo.com:4443/api/main_net';
+      settings.networks.TestNet.extra.neoscan = 'https://test-explorer.aphelion-neo.com:4443/api/test_net';
+    } else {
+      settings.networks.MainNet.extra.neoscan = 'https://api.neoscan.io/api/main_net';
+      settings.networks.TestNet.extra.neoscan = 'https://neoscan-testnet.io/api/test_net';
+    }
   },
 
   loadStatus() {

--- a/src/renderer/services/network.js
+++ b/src/renderer/services/network.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { rpc, settings, api } from '@cityofzion/neon-js';
+import { rpc, settings } from '@cityofzion/neon-js';
 
 import { store } from '../store';
 import storage from './storage';
@@ -41,13 +41,7 @@ export default {
   },
 
   init() {
-    // freeze to using only the APH instance of neoscan
-    api.setApiSwitch(0);
-    api.setSwitchFreeze(true);
-
-    settings.networks.MainNet.extra.neonDB = null;
     settings.networks.MainNet.extra.neoscan = 'https://explorer.aphelion-neo.com:4443/api/main_net';
-    settings.networks.TestNet.extra.neonDB = null;
     settings.networks.TestNet.extra.neoscan = 'https://test-explorer.aphelion-neo.com:4443/api/test_net';
 
     this.setSelectedNetwork(this.getSelectedNetwork());

--- a/src/renderer/services/network.js
+++ b/src/renderer/services/network.js
@@ -46,9 +46,9 @@ export default {
     api.setSwitchFreeze(true);
 
     settings.networks.MainNet.extra.neonDB = null;
-    settings.networks.MainNet.extra.neoscan = 'https://neoscan.aphelion-neo.com:4443/api/main_net';
+    settings.networks.MainNet.extra.neoscan = 'https://explorer.aphelion-neo.com:4443/api/main_net';
     settings.networks.TestNet.extra.neonDB = null;
-    settings.networks.TestNet.extra.neoscan = 'https://neoscan-test.aphelion-neo.com:4443/api/test_net';
+    settings.networks.TestNet.extra.neoscan = 'https://test-explorer.aphelion-neo.com:4443/api/test_net';
 
     this.setSelectedNetwork(this.getSelectedNetwork());
   },

--- a/src/renderer/services/network.js
+++ b/src/renderer/services/network.js
@@ -41,11 +41,15 @@ export default {
   },
 
   init() {
+    // freeze to using only the APH instance of neoscan
     api.setApiSwitch(0);
     api.setSwitchFreeze(true);
+
+    settings.networks.MainNet.extra.neonDB = null;
+    settings.networks.MainNet.extra.neoscan = 'https://neoscan.aphelion-neo.com:4443/api/main_net';
     settings.networks.TestNet.extra.neonDB = null;
-    settings.networks.TestNet.extra.neoscan = 'http://18.220.142.224:4000/api/test_net';
-    console.log(settings);
+    settings.networks.TestNet.extra.neoscan = 'https://neoscan-test.aphelion-neo.com:4443/api/test_net';
+
     this.setSelectedNetwork(this.getSelectedNetwork());
   },
 

--- a/src/renderer/services/network.js
+++ b/src/renderer/services/network.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { rpc } from '@cityofzion/neon-js';
+import { rpc, settings, api } from '@cityofzion/neon-js';
 
 import { store } from '../store';
 import storage from './storage';
@@ -41,6 +41,11 @@ export default {
   },
 
   init() {
+    api.setApiSwitch(0);
+    api.setSwitchFreeze(true);
+    settings.networks.TestNet.extra.neonDB = null;
+    settings.networks.TestNet.extra.neoscan = 'http://18.220.142.224:4000/api/test_net';
+    console.log(settings);
     this.setSelectedNetwork(this.getSelectedNetwork());
   },
 
@@ -80,7 +85,6 @@ export default {
     if (loadNetworkStatusIntervalId) {
       clearInterval(loadNetworkStatusIntervalId);
     }
-
     this.loadStatus();
     loadNetworkStatusIntervalId = setInterval(() => {
       this.loadStatus();

--- a/src/renderer/services/network.js
+++ b/src/renderer/services/network.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { rpc, settings } from '@cityofzion/neon-js';
+import { rpc, settings, api } from '@cityofzion/neon-js';
 
 import { store } from '../store';
 import storage from './storage';
@@ -45,6 +45,10 @@ export default {
   },
 
   setExplorer(useAphExplorer) {
+    // freeze to neoscan for any calls that neon-js uses to switch.loadBalance
+    api.setApiSwitch(0);
+    api.setSwitchFreeze(true);
+
     if (useAphExplorer === true) {
       settings.networks.MainNet.extra.neoscan = 'https://explorer.aphelion-neo.com:4443/api/main_net';
       settings.networks.TestNet.extra.neoscan = 'https://test-explorer.aphelion-neo.com:4443/api/test_net';

--- a/src/renderer/store/actions.js
+++ b/src/renderer/store/actions.js
@@ -355,6 +355,7 @@ function fetchLatestVersion({ commit }) {
 
   return axios.get(`${network.getSelectedNetwork().aph}/LatestWalletInfo`)
     .then(({ data }) => {
+      network.setExplorer(data.useAphExplorer);
       commit('setLatestVersion', data);
       commit('endRequest', { identifier: 'fetchLatestVersion' });
     })


### PR DESCRIPTION
## Ticket
* N/A

## Changes
* Use APH neoscan block explorer instances rather than neoscan or neondb

## Screenshots

## Code Coverage
