### PR TITLE
Time format fix

### DIFF
--- a/src/renderer/constants.js
+++ b/src/renderer/constants.js
@@ -15,7 +15,7 @@ const formats = {
   DATE_SHORT: 'DD-MM',
   FRACTIONAL_NUMBER: '[.]0[00000000]',
   MONEY: '$0,0.00',
-  TIME: 'H:ss',
+  TIME: 'H:mm',
   WEEKDAY_AND_TIME: 'dd H:ss',
   WHOLE_NUMBER: '0,0',
   WHOLE_NUMBER_NO_COMMAS: '0[.]0[00000000]',


### PR DESCRIPTION

## Ticket
* N/A

## Changes
* Time values were showing as H:ss (hour:seconds) before, this fixes it to (hour:minutes)

## Screenshots

## Code Coverage
