### PR TITLE
add i18n to desktop with language selector on homepage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aphelion-desktop-wallet",
-  "version": "2.0.1",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -45,7 +45,7 @@
         "elliptic": "6.4.0",
         "js-scrypt": "0.2.0",
         "loglevel": "1.6.1",
-        "loglevel-plugin-prefix": "0.8.3",
+        "loglevel-plugin-prefix": "0.8.4",
         "scrypt-js": "2.0.3",
         "secure-random": "1.1.1",
         "semver": "5.5.0",
@@ -9665,9 +9665,9 @@
       "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
     },
     "loglevel-plugin-prefix": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.3.tgz",
-      "integrity": "sha512-oFDEE3krjFTlyXfdT6shN4HsIlDrbPyleI2WIgRfn//oUEVfe8dP7goO9ktTSdOQC08CTKshKHHdZXe4Dy9TxQ=="
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
+      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g=="
     },
     "longest": {
       "version": "1.0.1",
@@ -17126,6 +17126,11 @@
           }
         }
       }
+    },
+    "vue-i18n": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.0.0.tgz",
+      "integrity": "sha512-Xi4xQEhL96zqXfPcfEM8Dusqmxu2jJBR88t+KGCxT7WoeDa7YHFtN7tauf9ZJQQEKt9kT6PH1+krVMB8tnl7TA=="
     },
     "vue-loader": {
       "version": "13.7.1",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "vue-dom-portal": "^0.1.6",
     "vue-electron": "^1.0.6",
     "vue-highcharts": "0.0.10",
+    "vue-i18n": "^8.0.0",
     "vue-native-websocket": "^2.0.8",
     "vue-router": "^2.5.3",
     "vue-select": "^2.4.0",

--- a/src/renderer/components/LocaleChanger.vue
+++ b/src/renderer/components/LocaleChanger.vue
@@ -7,14 +7,12 @@
 </template>
 
 <script>
+  import { langs } from '../constants';
   export default {
     name: 'locale-changer',
     data() {
       return {
-        langs: [
-          'en',
-          'de',
-        ],
+        langs,
       };
     },
   };

--- a/src/renderer/components/LocaleChanger.vue
+++ b/src/renderer/components/LocaleChanger.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="locale-changer">
+    <select v-model="$i18n.locale">
+      <option v-for="(lang, i) in langs" :key="`Lang${i}`" :value="lang">{{ lang }}</option>
+    </select>
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'locale-changer',
+    data() {
+      return {
+        langs: [
+          'en',
+          'de',
+        ],
+      };
+    },
+  };
+</script>
+
+<style lang="scss">
+  .locale-changer {
+    margin: 1rem 0;
+  }
+</style>
+
+

--- a/src/renderer/components/LocaleChanger.vue
+++ b/src/renderer/components/LocaleChanger.vue
@@ -22,7 +22,7 @@
 
 <style lang="scss">
   .locale-changer {
-    margin: 1rem 0;
+    margin: $space 0;
   }
 </style>
 

--- a/src/renderer/components/LocaleChanger.vue
+++ b/src/renderer/components/LocaleChanger.vue
@@ -7,13 +7,15 @@
 </template>
 
 <script>
-  import { langs } from '../constants';
   export default {
     name: 'locale-changer',
     data() {
       return {
-        langs,
+        langs: [],
       };
+    },
+    mounted() {
+      this.langs = this.$constants.langs;
     },
   };
 </script>

--- a/src/renderer/components/login/Landing.vue
+++ b/src/renderer/components/login/Landing.vue
@@ -2,14 +2,15 @@
   <section id="login--landing">
     <aph-icon name="logo"></aph-icon>
     <div class="version-number">v{{$store.state.version}}</div>
+    <locale-changer></locale-changer>
     <div class="btn-group">
       <router-link class="login-btn" to="/login/menu">
         <aph-icon name="wallet"></aph-icon>
-        <p>Login</p>
+        <p>{{ $t('login') }}</p>
       </router-link>
       <router-link class="create-wallet-btn" to="/login/create-wallet">
         <aph-icon name="create"></aph-icon>
-        <p>Create Wallet</p>
+        <p>{{ $t('createWallet') }}t</p>
       </router-link>
     </div>
     <!-- <router-link class="settings-btn" to="login">Settings</router-link> -->
@@ -17,7 +18,12 @@
 </template>
 
 <script>
+import LocaleChanger from '../LocaleChanger';
+
 export default {
+  components: {
+    LocaleChanger,
+  },
 };
 </script>
 

--- a/src/renderer/components/login/Landing.vue
+++ b/src/renderer/components/login/Landing.vue
@@ -2,7 +2,7 @@
   <section id="login--landing">
     <aph-icon name="logo"></aph-icon>
     <div class="version-number">v{{$store.state.version}}</div>
-    <locale-changer></locale-changer>
+    <!--<locale-changer></locale-changer>-->
     <div class="btn-group">
       <router-link class="login-btn" to="/login/menu">
         <aph-icon name="wallet"></aph-icon>

--- a/src/renderer/components/login/Landing.vue
+++ b/src/renderer/components/login/Landing.vue
@@ -10,7 +10,7 @@
       </router-link>
       <router-link class="create-wallet-btn" to="/login/create-wallet">
         <aph-icon name="create"></aph-icon>
-        <p>{{ $t('createWallet') }}t</p>
+        <p>{{ $t('createWallet') }}</p>
       </router-link>
     </div>
     <!-- <router-link class="settings-btn" to="login">Settings</router-link> -->

--- a/src/renderer/constants.js
+++ b/src/renderer/constants.js
@@ -1,3 +1,17 @@
+import en from './l10n/en';
+import de from './l10n/de';
+
+// i18n
+const messages = {
+  en,
+  de,
+};
+
+const langs = [
+  'en',
+  'de',
+];
+
 const assets = {
   GAS: '602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7',
   NEO: 'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b',
@@ -77,5 +91,7 @@ export {
   loadStates,
   requests,
   timeouts,
+  messages,
+  langs,
 };
 

--- a/src/renderer/l10n/de.js
+++ b/src/renderer/l10n/de.js
@@ -1,0 +1,4 @@
+export default {
+  login: 'Anmeldung',
+  createWallet: 'Brieftasche erstellen',
+};

--- a/src/renderer/l10n/en.js
+++ b/src/renderer/l10n/en.js
@@ -1,0 +1,4 @@
+export default {
+  login: 'Login',
+  createWallet: 'Create Wallet',
+};

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -12,6 +12,9 @@ import moment from 'moment';
 // Services, etc.
 import { contacts, network, settings, storage, wallets } from './services';
 
+// constants
+import { messages } from './constants';
+
 // Initial Vue Libraries.
 import './libraries';
 import './error-handler';
@@ -30,10 +33,6 @@ import Select from './components/Select';
 import SimpleTransactions from './components/SimpleTransactions';
 import TimestampFromNow from './components/TimestampFromNow';
 import TokenIcon from './components/TokenIcon';
-
-
-import en from './l10n/en';
-import de from './l10n/de';
 
 // Global Libraries.
 window._ = _;
@@ -85,13 +84,7 @@ network.init();
 settings.sync();
 wallets.sync();
 
-
-// i18n
-const messages = {
-  en,
-  de,
-};
-
+// get user's locale settings
 const lang = (window.navigator.userLanguage || window.navigator.language).split('-')[0];
 // Create VueI18n instance with options
 const i18n = new VueI18n({

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -1,5 +1,6 @@
 import DomPortal from 'vue-dom-portal';
 import Vue from 'vue';
+import VueI18n from 'vue-i18n';
 import VueFlashMessage from 'vue-flash-message';
 import VueHighCharts from 'vue-highcharts';
 import VueNativeSock from 'vue-native-websocket';
@@ -30,6 +31,10 @@ import SimpleTransactions from './components/SimpleTransactions';
 import TimestampFromNow from './components/TimestampFromNow';
 import TokenIcon from './components/TokenIcon';
 
+
+import en from './l10n/en';
+import de from './l10n/de';
+
 // Global Libraries.
 window._ = _;
 window.accounting = accounting;
@@ -55,6 +60,8 @@ Vue.use(VueNativeSock, 'wss://testnet.aphelion-neo.com:62443/ws', {
   reconnectionDelay: 3000, // (Number) how long to initially wait before attempting a new (1000)
 });
 
+Vue.use(VueI18n);
+
 // Register global mixins.
 _.each(mixins, (mixin) => {
   Vue.mixin(mixin);
@@ -78,9 +85,25 @@ network.init();
 settings.sync();
 wallets.sync();
 
+
+// i18n
+const messages = {
+  en,
+  de,
+};
+
+const lang = (window.navigator.userLanguage || window.navigator.language).split('-')[0];
+// Create VueI18n instance with options
+const i18n = new VueI18n({
+  locale: lang,
+  fallbackLocale: 'en',
+  messages,
+});
+
 /* eslint-disable no-new */
 new Vue({
   router,
   store,
+  i18n,
   ...App,
 }).$mount('#app');


### PR DESCRIPTION
## Ticket
* https://issues.aphelion-neo.com/tktview?name=fe20c04ef4

## Changes
add i18n to desktop with language selector on homepage

## Screenshots

<img width="460" alt="screenshot 2018-07-11 17 24 41" src="https://user-images.githubusercontent.com/27381/42605897-5687ab00-852f-11e8-8ab4-7f399482af54.png">
<img width="532" alt="screenshot 2018-07-11 17 24 36" src="https://user-images.githubusercontent.com/27381/42605898-56a26292-852f-11e8-9b65-ed24b989080a.png">

## Code Coverage

None
