### PR TITLE
add onSubmit handler to initial login form when hitting enter

### DIFF
--- a/src/renderer/components/login/SavedWallet.vue
+++ b/src/renderer/components/login/SavedWallet.vue
@@ -2,9 +2,11 @@
   <section id="login--saved-wallet">
     <login-form-wrapper identifier="openSavedWallet">
       <div v-if="wallets.length > 0">
-        <aph-select v-model="wallet" :options="wallets" :placeholder="$t('selectAWallet')"></aph-select>
-        <aph-input :hasError="$isFailed('openSavedWallet')" v-model="passphrase" :placeholder="$t('enterYourPassphrase')" type="password"></aph-input>
-        <button class="login" @click="login" :disabled="shouldDisableLoginButton">{{ buttonLabel }}</button>
+        <form @submit.prevent="login">
+          <aph-select v-model="wallet" :options="wallets" :placeholder="$t('selectAWallet')"></aph-select>
+          <aph-input :hasError="$isFailed('openSavedWallet')" v-model="passphrase" :placeholder="$t('enterYourPassphrase')" type="password"></aph-input>
+          <button class="login" :disabled="shouldDisableLoginButton">{{ buttonLabel }}</button>
+        </form>
       </div>
       <div v-else>
         <p class="help-text">{{$t('noSavedWallets')}}</p>


### PR DESCRIPTION


## Ticket
*https://issues.aphelion-neo.com/tktview/11b1dcd2ef7d2f738439bd86bb9ccc6616cb03e3

## Changes
- this speeds up the dev process when wallet refresh
 by not requiring a mouse click to login

## Screenshots

n/a

## Code Coverage

n/a