### PR TITLE
DEX: Left Nav 'toggle' state reset on logout .

### DIFF
--- a/src/renderer/store/mutations.js
+++ b/src/renderer/store/mutations.js
@@ -104,6 +104,7 @@ function handleLogout(state) {
   state.nep5Balances = {};
   state.sendInProgress = {};
   state.currentMarket = null;
+  state.menuToggleable = false;
   neo.fetchNEP5Tokens();
 }
 


### PR DESCRIPTION
## Ticket
* N/A

## Changes
* HandleLogout now resets the 'menuToggleable' state to false. 

## Screenshots
N/A

## Code Coverage