### PR TITLE
Dashboard/Send: Moving 'Amount' cleaning logic to 'blur' event.

### DIFF
--- a/src/renderer/components/Input.vue
+++ b/src/renderer/components/Input.vue
@@ -37,6 +37,10 @@ export default {
     },
 
     onBlur() {
+      if (this.$listeners.blur) {
+        this.$listeners.blur();
+      }
+
       this.isFocused = false;
     },
 

--- a/src/renderer/components/dashboard/Send.vue
+++ b/src/renderer/components/dashboard/Send.vue
@@ -54,7 +54,7 @@
             <aph-input :placeholder="$t('enterSendToAddress')" v-model="address"></aph-input>
           </div>
           <div class="amount">
-            <aph-input :placeholder="$t('enterAmount')" v-model="amount"></aph-input>
+            <aph-input @blur="cleanAmount" :placeholder="$t('enterAmount')" v-model="amount"></aph-input>
             <div class="symbol">{{ currency ? currency.value : '' }}</div>
             <div class="max" v-if="currency" @click="setAmountToMax">{{$t('max')}}</div>
           </div>
@@ -190,10 +190,7 @@ export default {
       }
 
       if (this.amount !== cleanAmount) {
-        setTimeout(() => {
-          // come off of the watch thread to set it
-          this.amount = cleanAmount;
-        }, 10);
+        this.amount = cleanAmount;
       }
     },
 
@@ -251,10 +248,6 @@ export default {
     },
 
     currency() {
-      this.cleanAmount();
-    },
-
-    amount() {
       this.cleanAmount();
     },
   },


### PR DESCRIPTION
## Ticket
* https://issues.aphelion-neo.com/tktview?name=77d84d4e8b

## Changes
* Update 'Send Token' component to 'clean up' amount on input blur event. Currently, it executes on every keystroke. This creates issues for amounts such as '1.03' where this value gets converted to '1' instantly as soon as the user types '1.0'.  

## Screenshots
N/A

## Code Coverage
