### PR TITLE
Update 'Trade History' to handle 'trades' websocket msg.

### DIFF
--- a/src/renderer/components/dex/TradeHistory.vue
+++ b/src/renderer/components/dex/TradeHistory.vue
@@ -25,12 +25,10 @@
 </template>
 
 <script>
-let loadTradesIntervalId;
 let storeUnwatch;
 export default {
 
   beforeDestroy() {
-    clearInterval(loadTradesIntervalId);
     storeUnwatch();
   },
 
@@ -43,9 +41,6 @@ export default {
 
   mounted() {
     this.loadTrades();
-    loadTradesIntervalId = setInterval(() => {
-      this.loadTradesSilently();
-    }, this.$constants.intervals.TRANSACTIONS_POLLING);
 
     storeUnwatch = this.$store.watch(
       () => {

--- a/src/renderer/store/mutations.js
+++ b/src/renderer/store/mutations.js
@@ -573,7 +573,7 @@ function tradeUpdateReceived(state, tradeUpdateMsg) {
     }
 
     state.tradeHistory.trades.unshift({
-      side: tradeUpdateMsg.side === 'ask' ? 'Buy' : 'Sell',
+      side: tradeUpdateMsg.side === 'ask' ? 'Sell' : 'Buy',
       price: trade[0],
       quantity: trade[1],
       tradeTime: moment(trade[2]).unix(),

--- a/src/renderer/store/mutations.js
+++ b/src/renderer/store/mutations.js
@@ -544,7 +544,6 @@ function SOCKET_RECONNECT_ERROR(state) {
   state.socket.reconnectError = true;
 }
 
-<<<<<<< HEAD
 function SOCKET_RECONNECT(state) {
   if (state.currentMarket) {
     this.dispatch('subscribeToMarket', {
@@ -552,7 +551,8 @@ function SOCKET_RECONNECT(state) {
       isRequestSilent: true,
     });
   }
-=======
+}
+
 function tradeUpdateReceived(state, tradeUpdateMsg) {
   if (!state.tradeHistory || !state.tradeHistory.trades) {
     return;
@@ -570,7 +570,6 @@ function tradeUpdateReceived(state, tradeUpdateMsg) {
       tradeTime: moment(t[2]).unix(),
     });
   });
->>>>>>> 602f383... Update 'Trade History' Component to use 'trades' msg. for trade updates (instead of REST polling)
 }
 
 // Local functions

--- a/src/renderer/store/mutations.js
+++ b/src/renderer/store/mutations.js
@@ -556,7 +556,7 @@ function SOCKET_RECONNECT(state) {
 
     // Ensure trade history is up-to-date on reconnect. (may have dropped some trades during disconnect)
     this.dispatch('fetchTradeHistory', {
-      marketName: this.$store.state.currentMarket.marketName,
+      marketName: state.currentMarket.marketName,
       isRequestSilent: true,
     });
   }

--- a/src/renderer/store/mutations.js
+++ b/src/renderer/store/mutations.js
@@ -532,6 +532,8 @@ function SOCKET_ONMESSAGE(state, message) {
     if (state.socket.orderMatchFailed) {
       state.socket.orderMatchFailed(message);
     }
+  } else if (message.type === 'trades') {
+    tradeUpdateReceived(state, message);
   } else if (message.type) {
     // unknown message type
     console.log(message);
@@ -542,6 +544,7 @@ function SOCKET_RECONNECT_ERROR(state) {
   state.socket.reconnectError = true;
 }
 
+<<<<<<< HEAD
 function SOCKET_RECONNECT(state) {
   if (state.currentMarket) {
     this.dispatch('subscribeToMarket', {
@@ -549,6 +552,25 @@ function SOCKET_RECONNECT(state) {
       isRequestSilent: true,
     });
   }
+=======
+function tradeUpdateReceived(state, tradeUpdateMsg) {
+  if (!state.tradeHistory || !state.tradeHistory.trades) {
+    return;
+  }
+
+  tradeUpdateMsg.trades.forEach((t) => {
+    if (t.length !== 3) {
+      return;
+    }
+
+    state.tradeHistory.trades.unshift({
+      side: tradeUpdateMsg.side === 'ask' ? 'Buy' : 'Sell',
+      price: t[0],
+      quantity: t[1],
+      tradeTime: moment(t[2]).unix(),
+    });
+  });
+>>>>>>> 602f383... Update 'Trade History' Component to use 'trades' msg. for trade updates (instead of REST polling)
 }
 
 // Local functions


### PR DESCRIPTION
## Ticket
* https://issues.aphelion-neo.com/tktview?name=f8c0f0d736

## Changes
* Update SOCKET_ONMESSAGE to accept new 'trades' message and perform an insert in to 'tradeHistory.trades' array.  
* Removed polling REST call to 'fetchTradeHistory'. (Updates are now received via websocket) 

## Screenshots
N/A

## Code Coverage
