### PR TITLE
Eliminate duplicate calls to CoinMarketCap (fetchHoldings)

### DIFF
--- a/src/renderer/services/valuation.js
+++ b/src/renderer/services/valuation.js
@@ -42,7 +42,7 @@ export default {
           axios.get(`${CMC_BASE_URL}ticker/?limit=1000&convert=${settings.getCurrency()}`)
             .then((res) => {
               lastCheckedTicker = moment.utc();
-              coinTickerList = _.values(res.data.data);
+              coinTickerList = _.values(res.data);
               resolve(_.find(coinTickerList, { symbol }));
             });
           return;

--- a/src/renderer/services/valuation.js
+++ b/src/renderer/services/valuation.js
@@ -38,24 +38,25 @@ export default {
   getValuation(symbol) {
     return new Promise((resolve, reject) => {
       try {
-        if (lastCheckedTicker && moment.utc().diff(lastCheckedTicker, 'seconds') < 60) {
-          let valuation = _.find(coinTickerList, { symbol });
-
-          if (!valuation) {
-            valuation = defaultValuation(symbol);
-            if (symbol === 'APH') {
-              valuation.total_supply = DEFAULT_APH_TOTAL_SUPPLY;
-            }
-          }
-          resolve(valuation);
+        if (!lastCheckedTicker || moment.utc().diff(lastCheckedTicker, 'seconds') >= 60) {
+          axios.get(`${CMC_BASE_URL}ticker/?limit=1000&convert=${settings.getCurrency()}`)
+            .then((res) => {
+              lastCheckedTicker = moment.utc();
+              coinTickerList = _.values(res.data.data);
+              resolve(_.find(coinTickerList, { symbol }));
+            });
+          return;
         }
 
-        axios.get(`${CMC_BASE_URL}ticker/?limit=1000&convert=${settings.getCurrency()}`)
-          .then((res) => {
-            lastCheckedTicker = moment.utc();
-            coinTickerList = res.data;
-            resolve(_.find(coinTickerList, { symbol }));
-          });
+        let valuation = _.find(coinTickerList, { symbol });
+
+        if (!valuation) {
+          valuation = defaultValuation(symbol);
+          if (symbol === 'APH') {
+            valuation.total_supply = DEFAULT_APH_TOTAL_SUPPLY;
+          }
+        }
+        resolve(valuation);
       } catch (e) {
         reject(e);
       }


### PR DESCRIPTION
## Ticket
* https://issues.aphelion-neo.com/tktview?name=3041eba647

## Changes
* Removed unnecessary duplicate calls to CoinMarketCap (during polling cycle). During each polling cycle, only one request is sent to CMC. 

## Screenshots
N/A

## Code Coverage
