### PR TITLE
Fix subscribing to market on websocket re-connect.

### DIFF
--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -36,6 +36,7 @@ const state = {
   markets: [],
   menuToggleable: false,
   menuCollapsed: true,
+  needsWsReconnectHandling: false,
   nep5Balances: {},
   orderBook: null,
   orderHistory: null,


### PR DESCRIPTION
I observed that after sitting on a market for a while if the websocket got disconnect it wasn't properly resubscribing to the market.

## Changes
* delay handling re-subscribe to market on websocket reconnect until after the new websocket connection is opened.
