### PR TITLE
Refactor generating chart trade bars

### DIFF
--- a/src/renderer/components/dex/Chart.vue
+++ b/src/renderer/components/dex/Chart.vue
@@ -73,6 +73,7 @@ let storeUnwatch;
 let storeMarketUnwatch;
 let tradingView;
 let barsSubscription;
+let lastPrice = 0;
 
 export default {
   data() {
@@ -192,10 +193,11 @@ export default {
           },
 
           getBars: (_symbolInfo, resolution, from, to, onDataCallback, onErrorCallback) => {
-            const bars = this.$store.state.tradeHistory.getBars(this.$store.state.tradeHistory, resolution, from, to);
+            const bars = this.$store.state.tradeHistory.getBars(this.$store.state.tradeHistory, resolution, from, to, lastPrice);
             if (bars.length === 0) {
               onDataCallback(bars, { noData: true })
             } else {
+              lastPrice = bars[bars.length - 1].close;
               onDataCallback(bars, { noData: false })
             }
           },


### PR DESCRIPTION
Cleaner method, walks forwards instead of backwards, works better on subsequent trades after a chart is open.

## Ticket
* 00cc7d54a4

## Changes
* Refactor generating chart trade bars
* Cleaner method, walks forwards instead of backwards, works better on subsequent trades after a chart is open.

## Screenshots

## Code Coverage
