### PR TITLE
Fix Commit Modal Styling

### DIFF
--- a/src/renderer/components/Commit.vue
+++ b/src/renderer/components/Commit.vue
@@ -1,6 +1,6 @@
 <template>
   <section id="commit-aph">
-    <div class="commit-header">
+    <div class="header commit-header">
       <h1>{{ $t('commit') }}.</h1>
       <button class="learn-more" @click="showInfo">{{ $t('learnMore') }}</button>
     </div>
@@ -254,13 +254,16 @@ export default {
   flex: 1;
   margin: $space-lg;
 
-  .commit-header {
-    color: $purple;
-    flex-basis: 15%;
-    font-family: 'GilroySemibold';
+  .header.commit-header {
     max-width: toRem(1105px);
     min-width: toRem(1150px);
     padding-left: $space-lg;
+  }
+
+  .header {
+    color: $purple;
+    flex-basis: 15%;
+    font-family: 'GilroySemibold';
 
     h1 {
       display: inline-block;

--- a/src/renderer/components/Commit.vue
+++ b/src/renderer/components/Commit.vue
@@ -1,6 +1,6 @@
 <template>
   <section id="commit-aph">
-    <div class="header">
+    <div class="commit-header">
       <h1>{{ $t('commit') }}.</h1>
       <button class="learn-more" @click="showInfo">{{ $t('learnMore') }}</button>
     </div>
@@ -254,7 +254,7 @@ export default {
   flex: 1;
   margin: $space-lg;
 
-  .header {
+  .commit-header {
     color: $purple;
     flex-basis: 15%;
     font-family: 'GilroySemibold';

--- a/src/renderer/components/Commit.vue
+++ b/src/renderer/components/Commit.vue
@@ -285,6 +285,11 @@ export default {
     }
   }
 
+  .body {
+    display: flex;
+    flex-direction: column;
+  }
+
   #commit-body {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Ticket
* None

## Changes
* Enhanced the header class so the styles set on the commit view header didn't conflict with the modal header styles. 

## Screenshots
<img width="611" alt="screen shot 2018-08-29 at 8 38 08 pm" src="https://user-images.githubusercontent.com/28928299/44822953-9fa68000-abcb-11e8-8aeb-2b649109b4f5.png">
