### PR TITLE
Remove redundant calls to getBlock and guard against not having latest block during fetchTransactionDetails

### DIFF
--- a/src/renderer/services/neo.js
+++ b/src/renderer/services/neo.js
@@ -326,17 +326,24 @@ export default {
       try {
         const inMemory = _.get(store.state.transactionDetails, hash);
         if (inMemory) {
-          inMemory.currentBlockHeight = network.getSelectedNetwork().bestBlock.index;
-          inMemory.confirmations = inMemory.currentBlockHeight - inMemory.block;
+          if (network.getSelectedNetwork().bestBlock) {
+            inMemory.currentBlockHeight = network.getSelectedNetwork().bestBlock.index;
+            inMemory.confirmations = inMemory.currentBlockHeight - inMemory.block;
+          }
           return resolve(inMemory);
         }
 
         return rpcClient.getRawTransaction(hash, 1)
           .then((transaction) => {
-            transaction.currentBlockHeight = network.getSelectedNetwork().bestBlock.index;
+            if (network.getSelectedNetwork().bestBlock) {
+              transaction.currentBlockHeight = network.getSelectedNetwork().bestBlock.index;
+            }
             if (transaction.confirmations > 0) {
               transaction.confirmed = true;
-              transaction.block = transaction.currentBlockHeight - transaction.confirmations;
+              if (transaction.currentBlockHeight) {
+                // TODO: switch to looking up the block from the blockhash
+                transaction.block = transaction.currentBlockHeight - transaction.confirmations;
+              }
             } else {
               transaction.confirmed = false;
             }

--- a/src/renderer/services/network.js
+++ b/src/renderer/services/network.js
@@ -96,13 +96,19 @@ export default {
 
     rpcClient.getBestBlockHash()
       .then((blockHash) => {
+        if (network.bestBlock && network.bestBlock.hash === blockHash) {
+          // Don't redundantly fetch the block we already fetched.
+          return;
+        }
         rpcClient.getBlock(blockHash)
           .then((data) => {
             if (network.bestBlock && network.bestBlock.index === data.index) {
+              // This should never happen now with the previous check above to not redundantly fetch the same block.
               return;
             }
             store.commit('setLastReceivedBlock');
             store.commit('setLastSuccessfulRequest');
+            // TODO: We should keep a cache with some information about blocks indexed by block hash.
             this.normalizeAndStore(_.set(network, 'bestBlock', data)).sync();
           })
           .catch((e) => {


### PR DESCRIPTION
## Changes
* Remove redundant calls to getBlock
* Guard against not having latest block during fetchTransactionDetails