### PR TITLE
DEX: Deposit/Withdraw Modal: Input 'amount' needs to be restricted to numbers and decimals.

### DIFF
--- a/src/renderer/components/Input.vue
+++ b/src/renderer/components/Input.vue
@@ -33,6 +33,10 @@ export default {
 
   methods: {
     onInput(event) {
+      if (this.isNumeric) {
+        event.target.value = event.target.value.replace(/[^\d.]/g, '');
+      }
+
       this.$emit('input', event.target.value);
     },
 
@@ -83,6 +87,11 @@ export default {
     value: {
       default: '',
       type: String,
+    },
+
+    isNumeric: {
+      default: false,
+      type: Boolean,
     },
   },
 };

--- a/src/renderer/components/dashboard/Send.vue
+++ b/src/renderer/components/dashboard/Send.vue
@@ -54,7 +54,7 @@
             <aph-input :placeholder="$t('enterSendToAddress')" v-model="address"></aph-input>
           </div>
           <div class="amount">
-            <aph-input @blur="cleanAmount" :placeholder="$t('enterAmount')" v-model="amount"></aph-input>
+            <aph-input :isNumeric="true" @blur="amount = $cleanAmount(amount, currency)" :placeholder="$t('enterAmount')" v-model="amount"></aph-input>
             <div class="symbol">{{ currency ? currency.value : '' }}</div>
             <div class="max" v-if="currency" @click="setAmountToMax">{{$t('max')}}</div>
           </div>
@@ -77,7 +77,6 @@
 </template>
 
 <script>
-import { BigNumber } from 'bignumber.js';
 import { mapGetters } from 'vuex';
 let sendTimeoutIntervalId;
 let storeUnwatch;
@@ -157,45 +156,6 @@ export default {
       }
     },
 
-    cleanAmount() {
-      if (!this.amount) {
-        return;
-      }
-
-      let cleanAmount = this.amount.replace(/[^\d.]/g, '');
-
-      const cleanSplit = _.split(cleanAmount, '.');
-      if (cleanSplit.length > 2) {
-        cleanAmount = `${cleanSplit[0]}.${cleanSplit[1]}`;
-      }
-
-      if (cleanAmount && cleanAmount.length > 0) {
-        if (this.currency) {
-          const fixed = 10 ** this.currency.decimals;
-          const cleanNumber = Math.floor(new BigNumber(cleanAmount).toNumber() * fixed) / fixed;
-          cleanAmount = new BigNumber(cleanNumber).toFixed(this.currency.decimals);
-        } else if (cleanAmount[cleanAmount.length - 1] !== '.'
-          && cleanAmount[cleanAmount.length - 1] !== '0') {
-          const n = new BigNumber(cleanAmount);
-          cleanAmount = this.$formatNumber(n, this.$constants.formats.WHOLE_NUMBER_NO_COMMAS);
-        }
-      }
-
-      // remove trailing zeros if there is a decimal
-      if (cleanAmount.indexOf('.') > -1) {
-        cleanAmount = _.trimEnd(cleanAmount, '0');
-      }
-
-      // remove decimal point if it is the last character
-      if (this.amount && this.amount.length > 0 && this.amount[this.amount.length - 1] !== '.') {
-        cleanAmount = _.trimEnd(cleanAmount, '.');
-      }
-
-      if (this.amount !== cleanAmount) {
-        this.amount = cleanAmount;
-      }
-    },
-
     send() {
       this.sending = true;
 
@@ -247,10 +207,6 @@ export default {
   watch: {
     address() {
       this.contact = this.$services.contacts.findContactByAddress(this.address);
-    },
-
-    currency() {
-      this.cleanAmount();
     },
   },
 

--- a/src/renderer/components/modals/DepositWithdrawModal.vue
+++ b/src/renderer/components/modals/DepositWithdrawModal.vue
@@ -15,7 +15,7 @@
         </div>
       </div>
       <div class="amount">
-        <aph-input @blur="cleanAmount" placeholder="Amount" :light="true" v-model="amount"></aph-input>
+        <aph-input :isNumeric="true" @blur="amount = $cleanAmount(amount, holding)" placeholder="Amount" :light="true" v-model="amount"></aph-input>
         <div class="max" v-if="hasAsset" @click="setAmountToMax">{{$t('max')}}</div>
       </div>
     </div>
@@ -28,7 +28,6 @@
 </template>
 
 <script>
-import { BigNumber } from 'bignumber.js';
 import ModalWrapper from './ModalWrapper';
 
 export default {
@@ -68,47 +67,6 @@ export default {
       this.amount = this.isDeposit ?
         this.holding.balance.toString() :
         this.holding.contractBalance.toString();
-
-      this.cleanAmount();
-    },
-
-    cleanAmount() {
-      if (!this.amount) {
-        return;
-      }
-
-      let cleanAmount = this.amount.replace(/[^\d.]/g, '');
-
-      const cleanSplit = _.split(cleanAmount, '.');
-      if (cleanSplit.length > 2) {
-        cleanAmount = `${cleanSplit[0]}.${cleanSplit[1]}`;
-      }
-
-      if (cleanAmount && cleanAmount.length > 0) {
-        if (this.holding) {
-          const fixed = 10 ** this.holding.decimals;
-          const cleanNumber = Math.floor(new BigNumber(cleanAmount).toNumber() * fixed) / fixed;
-          cleanAmount = new BigNumber(cleanNumber).toFixed(this.holding.decimals);
-        } else if (cleanAmount[cleanAmount.length - 1] !== '.'
-          && cleanAmount[cleanAmount.length - 1] !== '0') {
-          const n = new BigNumber(cleanAmount);
-          cleanAmount = this.$formatNumber(n, this.$constants.formats.WHOLE_NUMBER_NO_COMMAS);
-        }
-      }
-
-      // remove trailing zeros if there is a decimal
-      if (cleanAmount.indexOf('.') > -1) {
-        cleanAmount = _.trimEnd(cleanAmount, '0');
-      }
-
-      // remove decimal point if it is the last character
-      if (this.amount && this.amount.length > 0 && this.amount[this.amount.length - 1] !== '.') {
-        cleanAmount = _.trimEnd(cleanAmount, '.');
-      }
-
-      if (this.amount !== cleanAmount) {
-        this.amount = cleanAmount;
-      }
     },
   },
 

--- a/src/renderer/mixins/formatting.js
+++ b/src/renderer/mixins/formatting.js
@@ -37,5 +37,9 @@ export default {
     $formatTokenAmount(...args) {
       return formatting.formatTokenAmount.apply(null, args);
     },
+
+    $cleanAmount(...args) {
+      return formatting.cleanAmount.apply(null, args);
+    },
   },
 };

--- a/src/renderer/services/formatting.js
+++ b/src/renderer/services/formatting.js
@@ -107,4 +107,41 @@ export default {
     return toBigNumber(value).isGreaterThan(threshold) ?
       accounting.formatMoney(toBigNumber(value), '', 0) : formatNumberBase(value);
   },
+
+  cleanAmount(amount, currency) {
+    if (nullOrUndefined(amount)) {
+      return null;
+    }
+
+    let cleanAmount = amount.replace(/[^\d.]/g, '');
+
+    const cleanSplit = _.split(cleanAmount, '.');
+    if (cleanSplit.length > 2) {
+      cleanAmount = `${cleanSplit[0]}.${cleanSplit[1]}`;
+    }
+
+    if (cleanAmount && cleanAmount.length > 0) {
+      if (currency) {
+        const fixed = 10 ** currency.decimals;
+        const cleanNumber = Math.floor(new BigNumber(cleanAmount).toNumber() * fixed) / fixed;
+        cleanAmount = new BigNumber(cleanNumber).toFixed(currency.decimals);
+      } else if (cleanAmount[cleanAmount.length - 1] !== '.'
+        && cleanAmount[cleanAmount.length - 1] !== '0') {
+        const n = new BigNumber(cleanAmount);
+        cleanAmount = formatNumberBase(n, formats.WHOLE_NUMBER_NO_COMMAS);
+      }
+    }
+
+    // remove trailing zeros if there is a decimal
+    if (cleanAmount.indexOf('.') > -1) {
+      cleanAmount = _.trimEnd(cleanAmount, '0');
+    }
+
+    // remove decimal point if it is the last character
+    if (amount && amount.length > 0 && amount[amount.length - 1] !== '.') {
+      cleanAmount = _.trimEnd(cleanAmount, '.');
+    }
+
+    return cleanAmount;
+  },
 };


### PR DESCRIPTION
## Ticket
* https://issues.aphelion-neo.com/tktview?name=ff54ed98cd

## Changes
* Move 'cleanAmount' to formatting library, code was duplicated in both the 'Send' and 'Deposit/Withdraw' modal.
 * Added 'isNumeric' to aph-input to allow for only numeric characters. 
     ***** If a watcher is used to intercept and change the value - it flickers because it has already updated the model field with the incorrect data. Intercepting at the 'onInput' event allows for no flickering.

* isNumeric defaults to false (you must opt-in to use functionality)

## Screenshots
n/a

## Code Coverage
