### PR TITLE
DEX: Add tooltip for Post Only to explain what it does

### DIFF
--- a/src/renderer/components/dex/OrderForm.vue
+++ b/src/renderer/components/dex/OrderForm.vue
@@ -24,6 +24,7 @@
           </div>
           <div class="options">
             <div @click="postOnly = !postOnly" class="option" v-if="orderType === 'Limit'">
+              <aph-icon :title="postOnlyToolTip" class="post-only-info-icon" name="info"></aph-icon>
               <label>{{$t('postOnly')}}</label>
               <aph-icon name="radio-on" v-if="postOnly"></aph-icon>
               <aph-icon name="radio-off" v-else></aph-icon>
@@ -233,6 +234,13 @@ export default {
         const openOrdersBalance = this.aphHolding.openOrdersBalance
           ? this.$formatNumber(this.aphHolding.openOrdersBalance) : '0';
         return this.$t('walletBalanceContractBalance', { walletBalance, contractBalance, openOrdersBalance });
+      } catch (e) {
+        return '';
+      }
+    },
+    postOnlyToolTip() {
+      try {
+        return this.$t('postOnlyTooltip');
       } catch (e) {
         return '';
       }
@@ -734,7 +742,7 @@ export default {
     }
 
     .order-type {
-      margin: $space 0;
+      margin-top: $space;
     }
 
     .percentages {
@@ -749,7 +757,7 @@ export default {
 
         cursor: pointer;
         flex: 1;
-        padding: $space 0;
+        padding: $space-sm 0;
         text-align: center;
 
         &:hover {
@@ -793,6 +801,8 @@ export default {
     }
 
     .options {
+      display: flex;
+      justify-content: center;
       color: $grey;
       margin: $space 0 $space;
 
@@ -816,6 +826,10 @@ export default {
           .fill {
             fill: $dark-grey;
           }
+        }
+
+        .post-only-info-icon {
+          margin-right: $space-sm;
         }
       }
     }
@@ -925,7 +939,7 @@ export default {
     .label {
       @extend %small-uppercase-grey-label-dark;
 
-      flex: none
+      flex: none;
     }
 
     .value {
@@ -967,6 +981,12 @@ export default {
           .aph-icon {
             .fill {
               fill: $purple !important;
+            }
+          }
+
+          .post-only-info-icon {
+            .fill {
+              fill: $dark-grey !important;
             }
           }
         }

--- a/src/renderer/l10n/en.json
+++ b/src/renderer/l10n/en.json
@@ -190,6 +190,7 @@
   "pleaseEnterValidScriptHash": "Please enter a valid ICO script hash",
   "pleaseWaitForGas": "Please wait for the GAS claim to complete.",
   "postOnly": "Post Only",
+  "postOnlyTooltip": "Post Only option ensures the order won't match with a pre-existing order. If your order would cause a match with a pre-existing order, the order will be canceled. This ensures that you are the market maker and won't pay any fees.",
   "preferences": "Preferences",
   "price": "Price",
   "priceBase": "Price ({base})",


### PR DESCRIPTION
## Ticket
* https://issues.aphelion-neo.com/tktview/3285eff448cf5467144920e12bf9f743ca5d951b

## Changes
* Added 'Post Only' tooltip and icon. 
* Reduced excessive padding on percentages container.
* Removed bottom margin on 'order type' dropdown. 

## Screenshots
Day:
![image](https://user-images.githubusercontent.com/10226077/45399132-30398300-b604-11e8-9303-aaaf9f469f14.png)

Night: 
![image](https://user-images.githubusercontent.com/10226077/45399147-3def0880-b604-11e8-9217-13d7d2988a9b.png)


## Code Coverage
