### PR TITLE
DEX: Fixed disappearing OrderHistory component on network change.

### DIFF
--- a/src/renderer/components/dex/OrderHistory.vue
+++ b/src/renderer/components/dex/OrderHistory.vue
@@ -20,7 +20,7 @@
                   <th class="status">{{ $t('status') }}</th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody v-if="$store.state.currentMarket">
                 <tr v-for="(order, index) in filteredOrders" :key="index">
                   <td :class="['side', {green: order.side === 'Buy', red: order.side === 'Sell'}]">{{ order.side }}</td>
                   <td class="market">{{ order.marketName }}</td>


### PR DESCRIPTION
## Ticket
* N/A

## Changes
* Updates OrderHistory component to restrict rendering the tbody until the 'currentMarket' has been set and populated. The component template was breaking because it was attempting to access 'currentMarket' before it was populated. This ended up breaking the 'mount' method as well because the $refs object would not be populated since the view was broken. 

## Screenshots

## Code Coverage
