### PR TITLE
DEX: Fix unnecessary chart reload on socket_reconnect

### DIFF
--- a/src/renderer/store/mutations.js
+++ b/src/renderer/store/mutations.js
@@ -475,10 +475,14 @@ function orderBookUpdateReceived(state, res) {
 function setTradeHistory(state, trades) {
   if (state.tradeHistory == null ||
     (trades.marketName !== state.tradeHistory.marketName) ||
-    (trades.trades[0].tradeTime !== state.tradeHistory.trades[0].tradeTime) ||
-    (trades.trades[0].quantity !== state.tradeHistory.trades[0].quantity) ||
-    (trades.trades[0].price !== state.tradeHistory.trades[0].price) ||
-    (trades.trades[0].side !== state.tradeHistory.trades[0].side)) {
+    (trades.trades.length > 0 && state.tradeHistory.trades.length > 0
+        && trades.trades[0].tradeTime !== state.tradeHistory.trades[0].tradeTime) ||
+    (trades.trades.length > 0 && state.tradeHistory.trades.length > 0
+      && trades.trades[0].quantity !== state.tradeHistory.trades[0].quantity) ||
+    (trades.trades.length > 0 && state.tradeHistory.trades.length > 0
+      && trades.trades[0].price !== state.tradeHistory.trades[0].price) ||
+    (trades.trades.length > 0 && state.tradeHistory.trades.length > 0
+      && trades.trades[0].side !== state.tradeHistory.trades[0].side)) {
     state.tradeHistory = trades;
   }
 }

--- a/src/renderer/store/mutations.js
+++ b/src/renderer/store/mutations.js
@@ -473,7 +473,14 @@ function orderBookUpdateReceived(state, res) {
 }
 
 function setTradeHistory(state, trades) {
-  state.tradeHistory = trades;
+  if (state.tradeHistory == null ||
+    (trades.marketName !== state.tradeHistory.marketName) ||
+    (trades.trades[0].tradeTime !== state.tradeHistory.trades[0].tradeTime) ||
+    (trades.trades[0].quantity !== state.tradeHistory.trades[0].quantity) ||
+    (trades.trades[0].price !== state.tradeHistory.trades[0].price) ||
+    (trades.trades[0].side !== state.tradeHistory.trades[0].side)) {
+    state.tradeHistory = trades;
+  }
 }
 
 function setOrderHistory(state, orders) {


### PR DESCRIPTION
## Ticket
* N/A

## Changes
* Update 'setTradeHistory' to only do a complete update to 'tradeHistory' on: initial load of DEX, market change, or (socket_reconnect + new trades).

Note that a socket_reconnect alone will not trigger an update (requires new trades to trigger).

## Screenshots

## Code Coverage
