### PR TITLE
DEX: Order history flush on logout.

### DIFF
--- a/src/renderer/store/mutations.js
+++ b/src/renderer/store/mutations.js
@@ -113,6 +113,7 @@ function handleLogout(state) {
   state.sendInProgress = {};
   state.currentMarket = null;
   state.menuToggleable = false;
+  state.orderHistory = [];
   neo.fetchNEP5Tokens();
 }
 


### PR DESCRIPTION
## Ticket
* N/A

## Changes
* Order history flush on logout. Order were not being flushed when changing wallets (logging out)

## Screenshots

## Code Coverage
