### PR TITLE
Adjustments for Contract Update & Misc DEX fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aphelion-desktop-wallet",
-  "version": "2.7.9",
+  "version": "2.8.0",
   "author": "Aphelion <info@aphelion.org>",
   "description": "Aphelion Desktop Wallet",
   "license": "LicenseRef-LICENSE",

--- a/src/renderer/components/dex/Chart.vue
+++ b/src/renderer/components/dex/Chart.vue
@@ -213,8 +213,8 @@ export default {
               if (!this.tradingView || !this.tradingView._options) {
                 return;
               }
-              const to = parseInt((new Date().valueOf()) / 1000, 10)
-              const from = to - 120
+              const to = Math.round(new Date().valueOf() / 1000);
+              const from = to - 120;
 
               this.tradingView._options.datafeed.getBars(_symbolInfo, resolution, from, to, (bars) => {
                 if (bars.length === 0) {
@@ -230,8 +230,8 @@ export default {
                 const isNewBar = !Number.isNaN(lastBarTime) && lastBar.time > lastBarTime
 
                 if (isNewBar && bars.length >= 2) {
-                  const previousBar = bars[bars.length - 2]
-                  onRealtimeCallback(previousBar)
+                  const previousBar = bars[bars.length - 2];
+                  onRealtimeCallback(previousBar);
                 }
 
                 lastBarTime = lastBar.time;
@@ -247,7 +247,7 @@ export default {
                   throw err;
                 }
               })
-            }, 20000)
+            }, 10000)
           },
 
           unsubscribeBars: (subscriberUID) => {

--- a/src/renderer/components/dex/OrderForm.vue
+++ b/src/renderer/components/dex/OrderForm.vue
@@ -76,7 +76,7 @@
               <button @click="setMinimumClaimBlocks" class="footer-btn">Set Min Claim Blocks</button>
               <button @click="setMarket" class="footer-btn">Setup Market</button>
               <button @click="claimGasForDexContract" class="footer-btn">Claim DEX Gas</button>
-              <button @click="reclaimOrhphanFunds" class="footer-btn">Reclaim Orphan Funds</button>  -->
+              <button @click="reclaimOrhphanFunds" class="footer-btn">Reclaim Orphan Funds</button> -->
           </div>
        </div>
       </aph-spinner-wrapper>
@@ -633,125 +633,65 @@ export default {
     async setMarket() {
       this.$services.alerts.info('Add assets');
 
-      await this.$services.dex.setAssetSettings(this.$services.assets.APH, 0, true)
-        .then(async () => {
-          this.$services.alerts.success('Setup asset APH');
-          /*
-          await this.$services.dex.setAssetSettings(this.$services.assets.ATI, 0)
-            .then(() => {
-              this.$services.alerts.success('Setup asset ATI');
-            })
-            .catch((e) => {
-              this.$services.alerts.exception(e);
-            });
-            */
-          /* NXT2
-          await this.$services.dex.setAssetSettings('a3640dd3c560c75528e5f861da5da98958d0d713', 0)
-            .then(() => {
-              this.$services.alerts.success('Setup asset NXT2');
-            })
-            .catch((e) => {
-              this.$services.alerts.exception(e);
-            }); */
-          // try setting a 1.5 APH fee for withdraw of GAS
-          await this.$services.dex.setAssetSettings(this.$services.assets.GAS, 0, true)
-            .then(async () => {
-              this.$services.alerts.success('Set fee for withdraw for GAS');
-              await this.$services.dex.setAssetSettings(this.$services.assets.NEO, 0, true)
-                .then(async () => {
-                  this.$services.alerts.success('Set fee for withdraw for NEO');
+      try {
+        await this.$services.dex.setAssetSettings(this.$services.assets.APH, 0, true);
+        this.$services.alerts.success('Setup asset APH');
 
-                  await this.$services.dex.setMarket(this.$services.assets.APH,
-                    this.$services.assets.NEO,
-                    100, 0.0000001, 0, 0.25, true)
-                    .then(() => {
-                      this.$services.alerts.success(this.$t('setMarketRelayed'));
-                    })
-                    .catch((e) => {
-                      this.$services.alerts.exception(e);
-                    });
-                  await this.$services.dex.setMarket(this.$services.assets.GAS,
-                    this.$services.assets.NEO,
-                    2, 0.000001, 0.30946428, 0.30946428, true)
-                    .then(() => {
-                      this.$services.alerts.success(this.$t('setMarketRelayed'));
-                    })
-                    .catch((e) => {
-                      this.$services.alerts.exception(e);
-                    });
-                  // Set up all the markets after asset settings have been set.
-                  await this.$services.dex.setMarket(this.$services.assets.APH,
-                    this.$services.assets.GAS,
-                    100, 0.00001, 0.0000, 0.25, true)
-                    .then(() => {
-                      this.$services.alerts.success(this.$t('setMarketRelayed'));
-                    })
-                    .catch((e) => {
-                      this.$services.alerts.exception(e);
-                    });
-                  await this.$services.dex.setMarket(this.$services.assets.ATI,
-                    this.$services.assets.GAS,
-                    200, 0.00001, 0.25, 0.25)
-                    .then(() => {
-                      this.$services.alerts.success(this.$t('setMarketRelayed'));
-                    })
-                    .catch((e) => {
-                      this.$services.alerts.exception(e);
-                    });
-                  await this.$services.dex.setMarket(this.$services.assets.ATI,
-                    this.$services.assets.NEO,
-                    200, 0.00001, 0.25, 0.25)
-                    .then(() => {
-                      this.$services.alerts.success(this.$t('setMarketRelayed'));
-                    })
-                    .catch((e) => {
-                      this.$services.alerts.exception(e);
-                    });
-                  await this.$services.dex.setMarket(this.$services.assets.ATI,
-                    this.$services.assets.APH,
-                    200, 0.00001, 0.25, 0)
-                    .then(() => {
-                      this.$services.alerts.success(this.$t('setMarketRelayed'));
-                    })
-                    .catch((e) => {
-                      this.$services.alerts.exception(e);
-                    });
+        await this.$services.dex.setAssetSettings(this.$services.assets.ATI, 0, true);
+        this.$services.alerts.success('Setup asset ATI');
 
+        await this.$services.dex.setAssetSettings(this.$services.assets.GAS, 0, true);
+        this.$services.alerts.success('Setup asset GAS');
 
-                  /* NXT2
-                  await this.$services.dex.setMarket('a3640dd3c560c75528e5f861da5da98958d0d713',
-                    this.$services.assets.APH,
-                    10, 0.000001, 0.025, 0)
-                    .then(() => {
-                      this.$services.alerts.success(this.$t('setMarketRelayed'));
-                    })
-                    .catch((e) => {
-                      this.$services.alerts.exception(e);
-                    });
-                    */
-                  /*
-                  await this.$services.dex.setMarket('9aff1e08aea2048a26a3d2ddbb3df495b932b1e7',
-                    this.$services.assets.APH,
-                    1, 0.00001, 0.01, 0.01)
-                    .then(() => {
-                      this.$services.alerts.success(this.$t('setMarketRelayed'));
-                    })
-                    .catch((e) => {
-                      this.$services.alerts.exception(e);
-                    });
-                    */
-                })
-                .catch((e) => {
-                  this.$services.alerts.exception(e);
-                });
-            })
-            .catch((e) => {
-              this.$services.alerts.exception(e);
-            });
-        })
-        .catch((e) => {
-          this.$services.alerts.exception(e);
-        });
+        await this.$services.dex.setAssetSettings(this.$services.assets.NEO, 0, true);
+        this.$services.alerts.success('Setup asset NEO');
+
+        // await this.$services.dex.setAssetSettings('a3640dd3c560c75528e5f861da5da98958d0d713', 0);
+        // this.$services.alerts.success('Setup asset NXT2');
+        await this.$services.dex.setMarket(this.$services.assets.APH,
+          this.$services.assets.NEO,
+          100, 0.0000001, 0, 0.25, true);
+        this.$services.alerts.success('Setup Market NEO-APH');
+
+        await this.$services.dex.setMarket(this.$services.assets.GAS,
+          this.$services.assets.NEO,
+          2, 0.000001, 0.30946428, 0.30946428, true);
+        this.$services.alerts.success('Setup Market NEO-GAS');
+
+        await this.$services.dex.setMarket(this.$services.assets.APH,
+          this.$services.assets.GAS,
+          100, 0.00001, 0.0000, 0.25, true);
+        this.$services.alerts.success('Setup Market GAS-APH');
+
+        await this.$services.dex.setMarket(this.$services.assets.ATI,
+          this.$services.assets.GAS,
+          200, 0.00001, 0.25, 0.25);
+        this.$services.alerts.success('Setup Market GAS-ATI');
+
+        await this.$services.dex.setMarket(this.$services.assets.ATI,
+          this.$services.assets.NEO,
+          200, 0.00001, 0.25, 0.25);
+        this.$services.alerts.success('Setup Market NEO-ATI');
+
+        await this.$services.dex.setMarket(this.$services.assets.ATI,
+          this.$services.assets.APH,
+          200, 0.00001, 0.25, 0);
+        this.$services.alerts.success('Setup Market APH-ATI');
+
+        /*
+        await this.$services.dex.setMarket('a3640dd3c560c75528e5f861da5da98958d0d713',
+          this.$services.assets.APH,
+          10, 0.000001, 0.025, 0)
+        */
+
+        /* CTX
+        await this.$services.dex.setMarket('9aff1e08aea2048a26a3d2ddbb3df495b932b1e7',
+          this.$services.assets.APH,
+          1, 0.00001, 0.01, 0.01)
+        */
+      } catch (e) {
+        this.$services.alerts.exception(e);
+      }
     },
 
     async reclaimOrhphanFunds() {

--- a/src/renderer/components/dex/OrderForm.vue
+++ b/src/renderer/components/dex/OrderForm.vue
@@ -633,16 +633,18 @@ export default {
     async setMarket() {
       this.$services.alerts.info('Add assets');
 
-      await this.$services.dex.setAssetSettings(this.$services.assets.APH, 0)
+      await this.$services.dex.setAssetSettings(this.$services.assets.APH, 0, true)
         .then(async () => {
           this.$services.alerts.success('Setup asset APH');
-          this.$services.dex.setAssetSettings(this.$services.assets.ATI, 0)
+          /*
+          await this.$services.dex.setAssetSettings(this.$services.assets.ATI, 0)
             .then(() => {
               this.$services.alerts.success('Setup asset ATI');
             })
             .catch((e) => {
               this.$services.alerts.exception(e);
             });
+            */
           /* NXT2
           await this.$services.dex.setAssetSettings('a3640dd3c560c75528e5f861da5da98958d0d713', 0)
             .then(() => {
@@ -652,17 +654,53 @@ export default {
               this.$services.alerts.exception(e);
             }); */
           // try setting a 1.5 APH fee for withdraw of GAS
-          await this.$services.dex.setAssetSettings(this.$services.assets.GAS, 1.5)
+          await this.$services.dex.setAssetSettings(this.$services.assets.GAS, 0, true)
             .then(async () => {
               this.$services.alerts.success('Set fee for withdraw for GAS');
-              await this.$services.dex.setAssetSettings(this.$services.assets.NEO, 0)
+              await this.$services.dex.setAssetSettings(this.$services.assets.NEO, 0, true)
                 .then(async () => {
                   this.$services.alerts.success('Set fee for withdraw for NEO');
 
+                  await this.$services.dex.setMarket(this.$services.assets.APH,
+                    this.$services.assets.NEO,
+                    100, 0.0000001, 0, 0.25, true)
+                    .then(() => {
+                      this.$services.alerts.success(this.$t('setMarketRelayed'));
+                    })
+                    .catch((e) => {
+                      this.$services.alerts.exception(e);
+                    });
+                  await this.$services.dex.setMarket(this.$services.assets.GAS,
+                    this.$services.assets.NEO,
+                    2, 0.000001, 0.30946428, 0.30946428, true)
+                    .then(() => {
+                      this.$services.alerts.success(this.$t('setMarketRelayed'));
+                    })
+                    .catch((e) => {
+                      this.$services.alerts.exception(e);
+                    });
                   // Set up all the markets after asset settings have been set.
                   await this.$services.dex.setMarket(this.$services.assets.APH,
                     this.$services.assets.GAS,
-                    100, 0.00001, 0.0000, 0.25)
+                    100, 0.00001, 0.0000, 0.25, true)
+                    .then(() => {
+                      this.$services.alerts.success(this.$t('setMarketRelayed'));
+                    })
+                    .catch((e) => {
+                      this.$services.alerts.exception(e);
+                    });
+                  await this.$services.dex.setMarket(this.$services.assets.ATI,
+                    this.$services.assets.GAS,
+                    200, 0.00001, 0.25, 0.25)
+                    .then(() => {
+                      this.$services.alerts.success(this.$t('setMarketRelayed'));
+                    })
+                    .catch((e) => {
+                      this.$services.alerts.exception(e);
+                    });
+                  await this.$services.dex.setMarket(this.$services.assets.ATI,
+                    this.$services.assets.NEO,
+                    200, 0.00001, 0.25, 0.25)
                     .then(() => {
                       this.$services.alerts.success(this.$t('setMarketRelayed'));
                     })
@@ -678,42 +716,8 @@ export default {
                     .catch((e) => {
                       this.$services.alerts.exception(e);
                     });
-                  await this.$services.dex.setMarket(this.$services.assets.GAS,
-                    this.$services.assets.NEO,
-                    2, 0.000001, 0.30946428, 0.30946428)
-                    .then(() => {
-                      this.$services.alerts.success(this.$t('setMarketRelayed'));
-                    })
-                    .catch((e) => {
-                      this.$services.alerts.exception(e);
-                    });
-                  await this.$services.dex.setMarket(this.$services.assets.ATI,
-                    this.$services.assets.NEO,
-                    200, 0.00001, 0.25, 0.25)
-                    .then(() => {
-                      this.$services.alerts.success(this.$t('setMarketRelayed'));
-                    })
-                    .catch((e) => {
-                      this.$services.alerts.exception(e);
-                    });
-                  await this.$services.dex.setMarket(this.$services.assets.ATI,
-                    this.$services.assets.GAS,
-                    200, 0.00001, 0.25, 0.25)
-                    .then(() => {
-                      this.$services.alerts.success(this.$t('setMarketRelayed'));
-                    })
-                    .catch((e) => {
-                      this.$services.alerts.exception(e);
-                    });
-                  await this.$services.dex.setMarket(this.$services.assets.APH,
-                    this.$services.assets.NEO,
-                    100, 0.0000001, 0, 0.25)
-                    .then(() => {
-                      this.$services.alerts.success(this.$t('setMarketRelayed'));
-                    })
-                    .catch((e) => {
-                      this.$services.alerts.exception(e);
-                    });
+
+
                   /* NXT2
                   await this.$services.dex.setMarket('a3640dd3c560c75528e5f861da5da98958d0d713',
                     this.$services.assets.APH,
@@ -725,9 +729,8 @@ export default {
                       this.$services.alerts.exception(e);
                     });
                     */
-
                   /*
-                  this.$services.dex.setMarket('9aff1e08aea2048a26a3d2ddbb3df495b932b1e7',
+                  await this.$services.dex.setMarket('9aff1e08aea2048a26a3d2ddbb3df495b932b1e7',
                     this.$services.assets.APH,
                     1, 0.00001, 0.01, 0.01)
                     .then(() => {
@@ -736,7 +739,7 @@ export default {
                     .catch((e) => {
                       this.$services.alerts.exception(e);
                     });
-                  */
+                    */
                 })
                 .catch((e) => {
                   this.$services.alerts.exception(e);

--- a/src/renderer/components/dex/OrderForm.vue
+++ b/src/renderer/components/dex/OrderForm.vue
@@ -75,15 +75,16 @@
           <!-- Only the contract owner or manager can do this.
               <button @click="setMinimumClaimBlocks" class="footer-btn">Set Min Claim Blocks</button>
               <button @click="setMarket" class="footer-btn">Setup Market</button>
-              <button @click="claimGasForDexContract" class="footer-btn">Claim DEX Gas</button> -->
+              <button @click="claimGasForDexContract" class="footer-btn">Claim DEX Gas</button>
+              <button @click="reclaimOrhphanFunds" class="footer-btn">Reclaim Orphan Funds</button>  -->
           </div>
        </div>
       </aph-spinner-wrapper>
     </section>
     <aph-order-confirmation-modal v-if="$store.state.showOrderConfirmationModal"
-      :onConfirmed="orderConfirmed" :onCancel="hideOrderConfirmationModal"></aph-order-confirmation-modal>
+      :onConfirmed="orderConfirmed" :onCancel="hideOrderConfirmationModal" />
     <aph-deposit-withdraw-modal v-if="$store.state.depositWithdrawModalModel"
-      :onConfirmed="depositWithdrawConfirmed" :onCancel="hideDepositWithdrawModal"></aph-deposit-withdraw-modal>
+      :onConfirmed="depositWithdrawConfirmed" :onCancel="hideDepositWithdrawModal" />
   </div>
 </template>
 
@@ -630,72 +631,131 @@ export default {
     },
 
     async setMarket() {
-      await this.$services.dex.setMarket(this.$services.assets.APH,
-        this.$services.assets.GAS,
-        100, 0.00001, 0.0000, 0.25)
-        .then(() => {
-          this.$services.alerts.success(this.$t('setMarketRelayed'));
+      this.$services.alerts.info('Add assets');
+
+      await this.$services.dex.setAssetSettings(this.$services.assets.APH, 0)
+        .then(async () => {
+          this.$services.alerts.success('Setup asset APH');
+          this.$services.dex.setAssetSettings(this.$services.assets.ATI, 0)
+            .then(() => {
+              this.$services.alerts.success('Setup asset ATI');
+            })
+            .catch((e) => {
+              this.$services.alerts.exception(e);
+            });
+          /* NXT2
+          await this.$services.dex.setAssetSettings('a3640dd3c560c75528e5f861da5da98958d0d713', 0)
+            .then(() => {
+              this.$services.alerts.success('Setup asset NXT2');
+            })
+            .catch((e) => {
+              this.$services.alerts.exception(e);
+            }); */
+          // try setting a 1.5 APH fee for withdraw of GAS
+          await this.$services.dex.setAssetSettings(this.$services.assets.GAS, 1.5)
+            .then(async () => {
+              this.$services.alerts.success('Set fee for withdraw for GAS');
+              await this.$services.dex.setAssetSettings(this.$services.assets.NEO, 0)
+                .then(async () => {
+                  this.$services.alerts.success('Set fee for withdraw for NEO');
+
+                  // Set up all the markets after asset settings have been set.
+                  await this.$services.dex.setMarket(this.$services.assets.APH,
+                    this.$services.assets.GAS,
+                    100, 0.00001, 0.0000, 0.25)
+                    .then(() => {
+                      this.$services.alerts.success(this.$t('setMarketRelayed'));
+                    })
+                    .catch((e) => {
+                      this.$services.alerts.exception(e);
+                    });
+                  await this.$services.dex.setMarket(this.$services.assets.ATI,
+                    this.$services.assets.APH,
+                    200, 0.00001, 0.25, 0)
+                    .then(() => {
+                      this.$services.alerts.success(this.$t('setMarketRelayed'));
+                    })
+                    .catch((e) => {
+                      this.$services.alerts.exception(e);
+                    });
+                  await this.$services.dex.setMarket(this.$services.assets.GAS,
+                    this.$services.assets.NEO,
+                    2, 0.000001, 0.30946428, 0.30946428)
+                    .then(() => {
+                      this.$services.alerts.success(this.$t('setMarketRelayed'));
+                    })
+                    .catch((e) => {
+                      this.$services.alerts.exception(e);
+                    });
+                  await this.$services.dex.setMarket(this.$services.assets.ATI,
+                    this.$services.assets.NEO,
+                    200, 0.00001, 0.25, 0.25)
+                    .then(() => {
+                      this.$services.alerts.success(this.$t('setMarketRelayed'));
+                    })
+                    .catch((e) => {
+                      this.$services.alerts.exception(e);
+                    });
+                  await this.$services.dex.setMarket(this.$services.assets.ATI,
+                    this.$services.assets.GAS,
+                    200, 0.00001, 0.25, 0.25)
+                    .then(() => {
+                      this.$services.alerts.success(this.$t('setMarketRelayed'));
+                    })
+                    .catch((e) => {
+                      this.$services.alerts.exception(e);
+                    });
+                  await this.$services.dex.setMarket(this.$services.assets.APH,
+                    this.$services.assets.NEO,
+                    100, 0.0000001, 0, 0.25)
+                    .then(() => {
+                      this.$services.alerts.success(this.$t('setMarketRelayed'));
+                    })
+                    .catch((e) => {
+                      this.$services.alerts.exception(e);
+                    });
+                  /* NXT2
+                  await this.$services.dex.setMarket('a3640dd3c560c75528e5f861da5da98958d0d713',
+                    this.$services.assets.APH,
+                    10, 0.000001, 0.025, 0)
+                    .then(() => {
+                      this.$services.alerts.success(this.$t('setMarketRelayed'));
+                    })
+                    .catch((e) => {
+                      this.$services.alerts.exception(e);
+                    });
+                    */
+
+                  /*
+                  this.$services.dex.setMarket('9aff1e08aea2048a26a3d2ddbb3df495b932b1e7',
+                    this.$services.assets.APH,
+                    1, 0.00001, 0.01, 0.01)
+                    .then(() => {
+                      this.$services.alerts.success(this.$t('setMarketRelayed'));
+                    })
+                    .catch((e) => {
+                      this.$services.alerts.exception(e);
+                    });
+                  */
+                })
+                .catch((e) => {
+                  this.$services.alerts.exception(e);
+                });
+            })
+            .catch((e) => {
+              this.$services.alerts.exception(e);
+            });
         })
         .catch((e) => {
           this.$services.alerts.exception(e);
         });
-      await this.$services.dex.setMarket(this.$services.assets.ATI,
-        this.$services.assets.APH,
-        200, 0.00001, 0.25, 0)
-        .then(() => {
-          this.$services.alerts.success(this.$t('setMarketRelayed'));
-        })
-        .catch((e) => {
-          this.$services.alerts.exception(e);
-        });
-      await this.$services.dex.setMarket(this.$services.assets.NEO,
-        this.$services.assets.GAS,
-        0.5, 0.000001, 0.30946428, 0.30946428)
-        .then(() => {
-          this.$services.alerts.success(this.$t('setMarketRelayed'));
-        })
-        .catch((e) => {
-          this.$services.alerts.exception(e);
-        });
-      await this.$services.dex.setMarket(this.$services.assets.ATI,
-        this.$services.assets.NEO,
-        200, 0.00001, 0.25, 0.25)
-        .then(() => {
-          this.$services.alerts.success(this.$t('setMarketRelayed'));
-        })
-        .catch((e) => {
-          this.$services.alerts.exception(e);
-        });
-      await this.$services.dex.setMarket(this.$services.assets.ATI,
-        this.$services.assets.GAS,
-        200, 0.00001, 0.25, 0.25)
-        .then(() => {
-          this.$services.alerts.success(this.$t('setMarketRelayed'));
-        })
-        .catch((e) => {
-          this.$services.alerts.exception(e);
-        });
-      await this.$services.dex.setMarket(this.$services.assets.APH,
-        this.$services.assets.NEO,
-        100, 0.0000001, 0, 0.25)
-        .then(() => {
-          this.$services.alerts.success(this.$t('setMarketRelayed'));
-        })
-        .catch((e) => {
-          this.$services.alerts.exception(e);
-        });
-      /*
-      this.$services.dex.setMarket('9aff1e08aea2048a26a3d2ddbb3df495b932b1e7',
-        this.$constants.assets.APH,
-        1, 0.00001, 0.01, 0.01)
-        .then(() => {
-          this.$services.alerts.success(this.$t('setMarketRelayed'));
-        })
-        .catch((e) => {
-          this.$services.alerts.exception(e);
-        });
-      */
     },
+
+    async reclaimOrhphanFunds() {
+      this.$services.alerts.info('Start reclaim of orphaned GAS');
+      await this.$services.dex.reclaimOrphanFundsToOwner(this.$services.assets.GAS);
+    },
+
     setMinimumClaimBlocks() {
       this.$services.dex.setMinimumClaimBlocks(180)
         .then(() => {

--- a/src/renderer/components/modals/OrderConfirmationModal.vue
+++ b/src/renderer/components/modals/OrderConfirmationModal.vue
@@ -82,10 +82,10 @@
           </p>
           <p v-if="$store.state.orderToConfirm.feeDeposit && $store.state.orderToConfirm.feeDeposit.quantityToDeposit > 0">
             {{$t('thisOrderRequires', {
-                quantity: $formatNumber($store.state.orderToConfirm.feeDeposit.quantityRequired),
-                symbol: $store.state.orderToConfirm.feeDeposit.symbol,
-                balance: $formatNumber($store.state.orderToConfirm.feeDeposit.currentQuantity),
-                deposit: $formatNumber($store.state.orderToConfirm.feeDeposit.quantityToDeposit),
+                quantity: $formatNumber(this.$store.state.orderToConfirm.feeDeposit.quantityRequired),
+                symbol: this.$store.state.orderToConfirm.feeDeposit.symbol,
+                balance: $formatNumber(this.$store.state.orderToConfirm.feeDeposit.currentQuantity),
+                deposit: $formatNumber(this.$store.state.orderToConfirm.feeDeposit.quantityToDeposit),
               })
             }}
           </p>
@@ -149,6 +149,9 @@ export default {
     quantityToPullFromWallet() {
       let quantityToDeposit = this.$store.state.orderToConfirm.expectedQuantityToGive
         .minus(this.holdingForAssetToGive.contractBalance);
+      if (this.holdingForAssetToGive.assetId === this.$services.assets.APH) {
+        quantityToDeposit = quantityToDeposit.plus(this.$store.state.orderToConfirm.totalFees);
+      }
       if (this.holdingForAssetToGive.decimals < 8) {
         const toDepositTruncated = new BigNumber(quantityToDeposit.toFixed(this.holdingForAssetToGive.decimals));
         if (toDepositTruncated.isGreaterThanOrEqualTo(quantityToDeposit)) {

--- a/src/renderer/components/modals/OrderConfirmationModal.vue
+++ b/src/renderer/components/modals/OrderConfirmationModal.vue
@@ -73,7 +73,7 @@
         <div v-if="$store.state.orderToConfirm.assetIdToSell">
           <p v-if="quantityToPullFromWallet > 0">
             {{$t('thisOrderRequires', {
-                quantity: $formatNumber(this.$store.state.orderToConfirm.expectedQuantityToGive),
+                quantity: $formatNumber(expectedQuantityToGive),
                 symbol: holdingForAssetToGive.symbol,
                 balance: $formatNumber(holdingForAssetToGive.contractBalance),
                 deposit: $formatNumber(quantityToPullFromWallet),
@@ -146,10 +146,20 @@ export default {
       return _.find(this.$store.state.holdings, { assetId: this.$store.state.orderToConfirm.assetIdToSell });
     },
 
+    expectedQuantityToGive() {
+      let quantityNeeded = this.$store.state.orderToConfirm.expectedQuantityToGive;
+      if ((this.holdingForAssetToGive.assetId === this.$services.assets.APH)
+        && this.$store.state.orderToConfirm.totalFees) {
+        quantityNeeded = quantityNeeded.plus(this.$store.state.orderToConfirm.totalFees);
+      }
+      return quantityNeeded;
+    },
+
     quantityToPullFromWallet() {
       let quantityToDeposit = this.$store.state.orderToConfirm.expectedQuantityToGive
         .minus(this.holdingForAssetToGive.contractBalance);
-      if (this.holdingForAssetToGive.assetId === this.$services.assets.APH) {
+      if (this.holdingForAssetToGive.assetId === this.$services.assets.APH
+        && this.$store.state.orderToConfirm.totalFees) {
         quantityToDeposit = quantityToDeposit.plus(this.$store.state.orderToConfirm.totalFees);
       }
       if (this.holdingForAssetToGive.decimals < 8) {

--- a/src/renderer/components/settings/Preferences.vue
+++ b/src/renderer/components/settings/Preferences.vue
@@ -29,6 +29,13 @@
           <aph-select :light="true" :options="networkFees" :initialValue="selectedNetworkFee" v-model="selectedNetworkFee" :allow-empty-value="false"></aph-select>
         </div>
       </div>
+      <div class="row">
+        <div class="column fracture-gas" @click="toggleGasFracture">
+          <aph-icon name="radio-on" v-if="$store.state.gasFracture"></aph-icon>
+          <aph-icon name="radio-off" v-else></aph-icon>
+          <label>{{ $t('fractureGas') }}</label>
+        </div>
+      </div>
     </div>
   </section>
 </template>
@@ -79,6 +86,12 @@ export default {
       selectedNetwork: null,
       selectedNetworkFee: 0,
     };
+  },
+
+  methods: {
+    toggleGasFracture() {
+      this.$services.settings.toggleGasFracture();
+    },
   },
 
   watch: {
@@ -140,6 +153,31 @@ export default {
       .column {
         flex: 1;
         margin-right: $space;
+
+        &.fracture-gas {
+          align-items: center;
+          cursor: pointer;
+          display: flex;
+          flex-direction: row;
+          justify-content: center;
+
+          > label {
+            cursor: pointer;
+            font-family: GilroySemibold;
+            font-size: toRem(16px);
+            margin-left: $space;
+          }
+
+          > .aph-icon {
+            svg {
+              height: toRem(20px);
+            }
+
+            .fill {
+              fill: $dark-grey;
+            }
+          }
+        }
 
         &:last-child {
           margin-right: 0;

--- a/src/renderer/constants.js
+++ b/src/renderer/constants.js
@@ -46,7 +46,7 @@ const charts = {
 };
 
 const claiming = {
-  DEFAULT_CLAIM_BLOCKS: 180,
+  DEFAULT_CLAIM_BLOCKS: 4800,
 };
 
 const database = {

--- a/src/renderer/services/assets.js
+++ b/src/renderer/services/assets.js
@@ -10,7 +10,7 @@ export default {
   NEO: 'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b',
 
   // TODO: these different per network
-  DEX_SCRIPT_HASH: '4066b92f3ef198445807177937e98a81fb730d6b',
+  DEX_SCRIPT_HASH: '1317c59949c2546b76f11956d5081df619ba5317',
   APH: '591eedcd379a8981edeefe04ef26207e1391904a',
   ATI: '155153854ed377549a72cc1643e481bf25b48390',
 

--- a/src/renderer/services/dex.js
+++ b/src/renderer/services/dex.js
@@ -835,7 +835,7 @@ export default {
         if (order.assetIdToSell === assets.NEO) {
           const neoHolding = neo.getHolding(assets.NEO);
           if (neoHolding.contractBalance < order.quantityToSell) {
-            neoToSend = new BigNumber(order.quantityToSell - neoHolding.contractBalance);
+            neoToSend = toBigNumber(order.quantityToSell).minus(neoHolding.contractBalance);
 
             const toDepositTruncated = new BigNumber(neoToSend.toFixed(0));
             if (toDepositTruncated.isGreaterThanOrEqualTo(neoToSend)) {
@@ -854,7 +854,7 @@ export default {
         if (order.assetIdToSell === assets.GAS) {
           const gasHolding = neo.getHolding(assets.GAS);
           if (gasHolding.contractBalance < order.quantityToSell) {
-            gasToSend = new BigNumber(order.quantityToSell - gasHolding.contractBalance);
+            gasToSend = toBigNumber(order.quantityToSell).minus(gasHolding.contractBalance);
             if (gasToSend.isGreaterThan(gasHolding.balance)) {
               reject('Insufficient GAS.');
               return;

--- a/src/renderer/services/dex.js
+++ b/src/renderer/services/dex.js
@@ -288,7 +288,7 @@ export default {
     return new Promise((resolve, reject) => {
       try {
         const currentNetwork = network.getSelectedNetwork();
-        axios.get(`${currentNetwork.aph}/trades/bucketed/${marketName}?binSize=${binSize}`)
+        axios.get(`${currentNetwork.aph}/trades/bucketed/${marketName}?binSize=${binSize}?binCount=1440`)
           .then((res) => {
             resolve(res.data.buckets);
           })

--- a/src/renderer/services/dex.js
+++ b/src/renderer/services/dex.js
@@ -1977,7 +1977,7 @@ export default {
     });
   },
 
-  setMarket(quoteAssetId, baseAssetId, minimumSize, minimumTickSize, buyFee, sellFee) {
+  setMarket(quoteAssetId, baseAssetId, minimumSize, minimumTickSize, buyFee, sellFee, waitForTx) {
     return new Promise((resolve, reject) => {
       try {
         this.executeContractTransaction('setMarket',
@@ -1991,7 +1991,14 @@ export default {
           ])
           .then((res) => {
             if (res.success) {
-              resolve(res.tx);
+              if (waitForTx) {
+                neo.monitorTransactionConfirmation(res.tx, true)
+                  .then(() => {
+                    resolve(res.tx);
+                  });
+              } else {
+                resolve(res.tx);
+              }
             } else {
               reject('Transaction rejected');
             }
@@ -2263,7 +2270,7 @@ export default {
     });
   },
 
-  setAssetSettings(assetId, fee) {
+  setAssetSettings(assetId, fee, waitForTx) {
     return new Promise((resolve, reject) => {
       try {
         const settingsData = `00${u.num2fixed8(fee)}`;
@@ -2274,10 +2281,14 @@ export default {
           ])
           .then((res) => {
             if (res.success) {
-              neo.monitorTransactionConfirmation(res.tx, true)
-                .then(() => {
-                  resolve(res.tx);
-                });
+              if (waitForTx) {
+                neo.monitorTransactionConfirmation(res.tx, true)
+                  .then(() => {
+                    resolve(res.tx);
+                  });
+              } else {
+                resolve(res.tx);
+              }
             } else {
               reject('Transaction rejected');
             }

--- a/src/renderer/services/neo.js
+++ b/src/renderer/services/neo.js
@@ -764,7 +764,7 @@ export default {
   /**
    * @return Promise
    */
-  sendFunds(toAddress, assetId, amount, isNep5, callback) {
+  sendFunds(toAddress, assetId, amount, isNep5, callback, checkRpcForDetails) {
     return new Promise((resolve, reject) => {
       let sendPromise = null;
       try {
@@ -819,7 +819,7 @@ export default {
             }
 
             res.tx.lastBroadcasted = moment().utc();
-            return this.monitorTransactionConfirmation(res.tx)
+            return this.monitorTransactionConfirmation(res.tx, checkRpcForDetails)
               .then(() => {
                 return resolve(res.tx);
               })

--- a/src/renderer/services/settings.js
+++ b/src/renderer/services/settings.js
@@ -108,4 +108,11 @@ export default {
     return this;
   },
 
+  toggleGasFracture() {
+    storage.set(GAS_FRACTURE_STORAGE_KEY, !this.getGasFracture());
+    this.sync();
+
+    return this;
+  },
+
 };


### PR DESCRIPTION
## Changes
* Fix Confirmation dialog hang on deposit of UTXO based asset.
* Fix Confirmation dialog showing total APH needed to deposit when selling APH in an APH market.
* Fix Confirmation dialog showing fees that need to be pulled from wallet
* Fix UTXO storage keys after contract update to handle utxo index > 255
* Fix another rounding issue that could occur when converting a quantity to a BigNumber during order creation
* Update to new Contract Script Hash
* Update DEFAULT_CLAIM_BLOCKS to 4800
* Refresh chart faster + load a bit more history (still a lot more to do on the chart)