### PR TITLE
 DEX: Update 24 hour data to utilize 'Ticker' API

### DIFF
--- a/src/renderer/components/Dex.vue
+++ b/src/renderer/components/Dex.vue
@@ -52,15 +52,9 @@ export default {
   mounted() {
     this.$store.state.showPortfolioHeader = false;
     this.loadMarkets();
+    this.loadTickerData();
 
     this.$services.dex.completeSystemAssetWithdrawals();
-
-    this.tickerRefreshInterval = setInterval(() => {
-      this.$services.dex.fetchTickerData()
-        .then((tickerData) => {
-          this.$store.commit('setTickerDataByMarket', tickerData);
-        });
-    }, this.$constants.intervals.TICKER_POLLING);
 
     this.$store.commit('setSocketOrderCreated', (message) => {
       /* eslint-disable max-len */
@@ -125,6 +119,9 @@ export default {
     this.completeSystemAssetWithdrawalsInterval = setInterval(() => {
       this.$services.dex.completeSystemAssetWithdrawals();
     }, this.$constants.intervals.COMPLETE_SYSTEM_WITHDRAWALS);
+    this.tickerRefreshInterval = setInterval(() => {
+      this.loadTickerData();
+    }, this.$constants.intervals.TICKER_POLLING);
   },
 
   data() {
@@ -170,6 +167,12 @@ export default {
           }
         },
       });
+    },
+    loadTickerData() {
+      this.$services.dex.fetchTickerData()
+        .then((tickerData) => {
+          this.$store.commit('setTickerDataByMarket', tickerData);
+        });
     },
   },
 };

--- a/src/renderer/components/Dex.vue
+++ b/src/renderer/components/Dex.vue
@@ -46,6 +46,7 @@ export default {
     clearInterval(this.connectionStatusInterval);
     clearInterval(this.marketsRefreshInterval);
     clearInterval(this.completeSystemAssetWithdrawalsInterval);
+    clearInterval(this.tickerRefreshInterval);
   },
 
   mounted() {
@@ -53,6 +54,13 @@ export default {
     this.loadMarkets();
 
     this.$services.dex.completeSystemAssetWithdrawals();
+
+    this.tickerRefreshInterval = setInterval(() => {
+      this.$services.dex.fetchTickerData()
+        .then((tickerData) => {
+          this.$store.commit('setTickerDataByMarket', tickerData);
+        });
+    }, this.$constants.intervals.TICKER_POLLING);
 
     this.$store.commit('setSocketOrderCreated', (message) => {
       /* eslint-disable max-len */

--- a/src/renderer/components/dex/MarketSelection.vue
+++ b/src/renderer/components/dex/MarketSelection.vue
@@ -21,19 +21,19 @@
         <div class="day-values">
           <div class="row">
             <div class="label">{{$t('vol')}}</div>
-            <div class="value">{{ $formatNumber($store.state.tradeHistory ? $store.state.tradeHistory.volume24Hour : 0) }}</div>
+            <div class="value">{{ tickerData.quoteVolume }}</div>
           </div>
           <div class="row">
             <div class="label">{{$t('OPEN')}}</div>
-            <div class="value">{{ $formatTokenAmount($store.state.tradeHistory ? $store.state.tradeHistory.open24Hour : 0) }}</div>
+            <div class="value">{{ $formatTokenAmount(tickerData.open24hr) }}</div>
           </div>
-          <div class="row">
+          <div class="row"> 
             <div class="label">{{$t('HIGH')}}</div>
-            <div class="value">{{ $formatTokenAmount($store.state.tradeHistory ? $store.state.tradeHistory.high24Hour : 0) }}</div>
+            <div class="value">{{ $formatTokenAmount(tickerData.high24hr) }}</div>
           </div>
           <div class="row">
             <div class="label">{{$t('LOW')}}</div>
-            <div class="value">{{ $formatTokenAmount($store.state.tradeHistory ? $store.state.tradeHistory.low24Hour : 0) }}</div>
+            <div class="value">{{ $formatTokenAmount(tickerData.low24hr) }}</div>
           </div>
         </div>
         <div class="token-details">
@@ -45,8 +45,8 @@
             {{ $formatMoney($store.state.tradeHistory ? $store.state.tradeHistory.close24Hour * baseCurrencyUnitPrice : 0) }}
           </div>
           <span class="label">{{ $t('change24H') }} ({{ $store.state.currentMarket ? $store.state.currentMarket.quoteCurrency : '' }})</span>
-          <div :class="['change', {decrease: $store.state.tradeHistory ? $store.state.tradeHistory.change24Hour < 0 : false, increase: $store.state.tradeHistory ? $store.state.tradeHistory.change24Hour > 0 : false}]">
-            {{ $formatNumber($store.state.tradeHistory ? $store.state.tradeHistory.change24Hour : 0) }}
+          <div :class="['change', {decrease: change24Hour < 0, increase: change24Hour > 0 }]">
+            {{ $formatNumber(change24Hour) }}
             ({{ $formatNumber(percentChangeAbsolute) }}%)
           </div>
         </div>
@@ -56,6 +56,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
 import MarketMegaSelector from './MarketMegaSelector';
 
 export default {
@@ -72,9 +73,16 @@ export default {
         this.$services.neo.getHolding(this.storeStateCurrentMarket.baseAssetId).unitValue : 0;
     },
     percentChangeAbsolute() {
-      return this.$store.state.tradeHistory ?
-        Math.abs(this.$store.state.tradeHistory.change24HourPercent) : 0;
+      return Math.round(((this.change24Hour)
+        / this.tickerData.open24hr) * 10000) / 100;
     },
+    change24Hour() {
+      return this.$store.state.tradeHistory ?
+        (this.$store.state.tradeHistory.close24Hour - this.tickerData.open24hr) : 0;
+    },
+    ...mapGetters([
+      'tickerData',
+    ]),
   },
 
   methods: {

--- a/src/renderer/constants.js
+++ b/src/renderer/constants.js
@@ -81,6 +81,7 @@ const intervals = {
   TOKENS_BALANCES_POLL_ALL: 5 * 60 * 1000,
   TRANSACTIONS_POLLING: 15 * 1000,
   WALLET_VERSION_CHECK: 10 * 60 * 1000,
+  TICKER_POLLING: 2 * 60 * 1000,
 };
 
 const loadStates = {

--- a/src/renderer/services/dex.js
+++ b/src/renderer/services/dex.js
@@ -2340,4 +2340,21 @@ export default {
       }
     });
   },
+
+  fetchTickerData() {
+    return new Promise((resolve, reject) => {
+      try {
+        const currentNetwork = network.getSelectedNetwork();
+        axios.get(`${currentNetwork.aph}/ticker`)
+          .then((res) => {
+            resolve(res.data);
+          })
+          .catch((e) => {
+            alerts.exception(`APH API Error: ${e}`);
+          });
+      } catch (e) {
+        reject(`Failed to fetch ticker data. ${e.message}`);
+      }
+    });
+  },
 };

--- a/src/renderer/store/getters.js
+++ b/src/renderer/store/getters.js
@@ -45,3 +45,6 @@ export const tradeHistory = state => state.tradeHistory;
 export const transactionDetails = state => state.transactionDetails;
 export const version = state => state.version;
 export const wallets = state => state.wallets;
+export const tickerData = (state) => {
+  return state.currentMarket ? state.tickerDataByMarket[state.currentMarket.marketName] : {};
+};

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -76,6 +76,7 @@ const state = {
   styleMode: 'Night',
   tradeHistory: null,
   transactionDetails: {},
+  tickerDataByMarket: {},
   version: pjson.version,
   wallets: [],
 };

--- a/src/renderer/store/mutations.js
+++ b/src/renderer/store/mutations.js
@@ -71,6 +71,7 @@ export {
   setSocketOrderMatchFailed,
   setStatsToken,
   setStyleMode,
+  setTickerDataByMarket,
   setTradeHistory,
   setWallets,
   startRequest,
@@ -453,6 +454,10 @@ function setOrderPrice(state, price) {
 
 function setOrderQuantity(state, quantity) {
   state.orderQuantity = quantity;
+}
+
+function setTickerDataByMarket(state, tickerDataByMarket) {
+  state.tickerDataByMarket = tickerDataByMarket;
 }
 
 function orderBookSnapshotReceived(state, res) {


### PR DESCRIPTION
## Ticket
* N/A

## Changes
* Update 24 Hour Data to use 'Ticker' API exposed by APH.API. However, use the 'websocket' trades to compute 'Last' value and related fields (change 24 hr)

## Screenshots

## Code Coverage
