### PR TITLE
System Asset Withdraw: Allow only one in progess; disable network switch

### DIFF
--- a/src/renderer/components/Select.vue
+++ b/src/renderer/components/Select.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="['aph-select', {'is-open': isOpen, 'is-light': light}]">
-    <button class="aph-select--label" :disabled="isDisabled" @click="toggleOpen">{{ label }}</button>
+    <button :title="disabledTooltip" type="button" class="aph-select--label" :disabled="isDisabled" @click="toggleOpen">{{ label }}</button>
     <ul class="aph-select--dropdown" v-if="isOpen">
       <li :class="{selected: isSelected(option)}" v-for="(option, index) in options" :key="index" @click="toggleSelectedOption(option)">{{ option.label }}</li>
     </ul>
@@ -29,6 +29,9 @@ export default {
 
     label() {
       return this.getSelectedOptionLabel() || this.placeholder;
+    },
+    disabledTooltip() {
+      return this.isDisabled ? this.isDisabledTooltip : '';
     },
   },
 
@@ -108,10 +111,13 @@ export default {
       },
       type: String,
     },
-
     isDisabled: {
       default: false,
       type: Boolean,
+    },
+    isDisabledTooltip: {
+      default: '',
+      type: String,
     },
   },
 };

--- a/src/renderer/components/Select.vue
+++ b/src/renderer/components/Select.vue
@@ -54,6 +54,10 @@ export default {
     },
 
     toggleOpen() {
+      if (this.isDisabled) {
+        return;
+      }
+
       this.isOpen = !this.isOpen;
     },
 
@@ -107,6 +111,11 @@ export default {
         return this.$t('noOptionSelected');
       },
       type: String,
+    },
+
+    isDisabled: {
+      default: false,
+      type: Boolean,
     },
   },
 };

--- a/src/renderer/components/Select.vue
+++ b/src/renderer/components/Select.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="['aph-select', {'is-open': isOpen, 'is-light': light}]">
-    <button :title="disabledTooltip" type="button" class="aph-select--label" :disabled="isDisabled" @click="toggleOpen">{{ label }}</button>
+    <button type="button" class="aph-select--label" :disabled="isDisabled" :title="disabledTooltip" @click="toggleOpen">{{ label }}</button>
     <ul class="aph-select--dropdown" v-if="isOpen">
       <li :class="{selected: isSelected(option)}" v-for="(option, index) in options" :key="index" @click="toggleSelectedOption(option)">{{ option.label }}</li>
     </ul>

--- a/src/renderer/components/Select.vue
+++ b/src/renderer/components/Select.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="['aph-select', {'is-open': isOpen, 'is-light': light}]">
-    <div class="aph-select--label" @click="toggleOpen">{{ label }}</div>
+    <button class="aph-select--label" :disabled="isDisabled" @click="toggleOpen">{{ label }}</button>
     <ul class="aph-select--dropdown" v-if="isOpen">
       <li :class="{selected: isSelected(option)}" v-for="(option, index) in options" :key="index" @click="toggleSelectedOption(option)">{{ option.label }}</li>
     </ul>
@@ -54,10 +54,6 @@ export default {
     },
 
     toggleOpen() {
-      if (this.isDisabled) {
-        return;
-      }
-
       this.isOpen = !this.isOpen;
     },
 
@@ -173,6 +169,8 @@ export default {
     text-align: center;
     transition: all .1s linear;
     white-space: nowrap;
+    outline:none;
+    width: 100%;
 
     &:hover {
       background: $purple-hover;

--- a/src/renderer/components/dex/MarketSelection.vue
+++ b/src/renderer/components/dex/MarketSelection.vue
@@ -74,6 +74,10 @@ export default {
         / this.tickerData.open24hr) * 10000) / 100;
     },
     change24Hour() {
+      if (this.$isPending('fetchTradeHistory')) {
+        return 0;
+      }
+
       return new BigNumber(String(this.close24Hour))
         .minus(new BigNumber(String(this.tickerData.open24hr)));
     },

--- a/src/renderer/components/dex/OrderForm.vue
+++ b/src/renderer/components/dex/OrderForm.vue
@@ -608,6 +608,13 @@ export default {
       });
     },
     showDepositWithdrawModal(isDeposit) {
+      if (this.$services.dex.isSystemAssetWithdrawInProgress()) {
+        this.$store.commit('setWithdrawInProgressModalModel', {
+        });
+
+        return;
+      }
+
       this.$store.commit('setDepositWithdrawModalModel', {
         // NOTE: if whitelisted, adjust assetId to test a new asset that has been whitelisted but market not yet added.
         isDeposit, holdingAssetId: this.actionableHolding.assetId,

--- a/src/renderer/components/dex/OrderForm.vue
+++ b/src/renderer/components/dex/OrderForm.vue
@@ -608,9 +608,8 @@ export default {
       });
     },
     showDepositWithdrawModal(isDeposit) {
-      if (this.$services.dex.isSystemAssetWithdrawInProgress()) {
-        this.$store.commit('setWithdrawInProgressModalModel', {
-        });
+      if (!isDeposit && this.$services.dex.isSystemAssetWithdrawInProgress()) {
+        this.$store.commit('setWithdrawInProgressModalModel', {});
 
         return;
       }

--- a/src/renderer/components/dex/OrderForm.vue
+++ b/src/renderer/components/dex/OrderForm.vue
@@ -608,7 +608,8 @@ export default {
       });
     },
     showDepositWithdrawModal(isDeposit) {
-      if (!isDeposit && this.$services.dex.isSystemAssetWithdrawInProgress()) {
+      if ((this.actionableHolding.symbol === 'GAS' || this.actionableHolding.symbol === 'NEO') &&
+       !isDeposit && this.$services.dex.isSystemAssetWithdrawInProgress()) {
         this.$store.commit('setWithdrawInProgressModalModel', {});
 
         return;

--- a/src/renderer/components/settings/Preferences.vue
+++ b/src/renderer/components/settings/Preferences.vue
@@ -22,7 +22,7 @@
       <div class="row">
         <div class="column">
           <div class="label">{{$t('network')}}</div>
-          <aph-select :light="true" :options="networks" :initialValue="selectedNetwork" v-model="selectedNetwork" :allow-empty-value="false"></aph-select>
+          <aph-select :light="true" :options="networks" :isDisabled="isSystemAssetWithdrawInProgress" :initialValue="selectedNetwork" v-model="selectedNetwork" :allow-empty-value="false"></aph-select>
         </div>
         <div class="column">
           <div class="label">{{$t('networkFee')}}</div>
@@ -123,6 +123,12 @@ export default {
     selectedLanguage(language) {
       this.$i18n.locale = language;
       localStorage.setItem('language', language);
+    },
+  },
+
+  computed: {
+    isSystemAssetWithdrawInProgress() {
+      return this.$services.dex.isSystemAssetWithdrawInProgress();
     },
   },
 };

--- a/src/renderer/components/settings/Preferences.vue
+++ b/src/renderer/components/settings/Preferences.vue
@@ -22,7 +22,7 @@
       <div class="row">
         <div class="column">
           <div class="label">{{$t('network')}}</div>
-          <aph-select :light="true" :options="networks" :isDisabled="isSystemAssetWithdrawInProgress" :initialValue="selectedNetwork" v-model="selectedNetwork" :allow-empty-value="false"></aph-select>
+          <aph-select :light="true" :options="networks" :isDisabledTooltip="$t('networkSwitchBtnDisabled')" :isDisabled="shouldDisableNetworkSelection" :initialValue="selectedNetwork" v-model="selectedNetwork" :allow-empty-value="false"></aph-select>
         </div>
         <div class="column">
           <div class="label">{{$t('networkFee')}}</div>
@@ -127,7 +127,7 @@ export default {
   },
 
   computed: {
-    isSystemAssetWithdrawInProgress() {
+    shouldDisableNetworkSelection() {
       return this.$services.dex.isSystemAssetWithdrawInProgress();
     },
   },

--- a/src/renderer/l10n/en.json
+++ b/src/renderer/l10n/en.json
@@ -251,7 +251,7 @@
   "theDexContractHasBeenUpdated": "The DEX contract has been updated. A corresponding wallet upgrade is required to continue to use the DEX. Please use the controls below to cancel your orders and withdraw your funds from the contract back to your wallet and then download the latest version.",
   "theFeeForCompletingYourTradeWillBe": "The fee for completing your trade will be {amount} APH",
   "theFeeForCompletingYourTradeWillDepend": "The fee for completing your trade will depend on the final number of offers matched but will be between {min} APH and {max} APH",
-  "thisIsAPreliminaryDemo": "This is a preliminary demo and testing version of the Aphelion DEX. It operates on Neo Testnet, which may exhibit degraded performance. Mainnet coming soon.",
+  "thisIsAPreliminaryDemo": "This is a preliminary demo and testing version of the Aphelion DEX. It operates on Neo Testnet, which may exhibit degraded performance.",
   "thisMeansThatItIsIneligible": "This means that it is ineligible as a Post Only order.",
   "thisOrderRequires": "This order requires {quantity} {symbol} to be completed. Your current contract balance is only {balance} {symbol}. Submitting this order will first submit {deposit} {symbol} in order to process successfully.",
   "thisOrderWouldTakeTheFollowing": "This order would take the following offers:",

--- a/src/renderer/l10n/en.json
+++ b/src/renderer/l10n/en.json
@@ -162,6 +162,7 @@
   "name": "Name",
   "network": "Network",
   "networkFee": "Network Fee",
+  "networkSwitchBtnDisabled": "System operation(s) in progress: Please wait until operations complete before attempting to switching networks",
   "networkWeight": "Network Weight",
   "neverAskAgain": "No, Never",
   "newVersionAvailable": "A new version is available.",

--- a/src/renderer/services/dex.js
+++ b/src/renderer/services/dex.js
@@ -2579,7 +2579,6 @@ export default {
   },
   isSystemAssetWithdrawInProgress() {
     const systemWithdrawStep = _.get(store.state, 'systemWithdraw.step');
-
     return systemWithdrawStep >= 0 && systemWithdrawStep < 5;
   },
 };

--- a/src/renderer/services/dex.js
+++ b/src/renderer/services/dex.js
@@ -2580,6 +2580,6 @@ export default {
   isSystemAssetWithdrawInProgress() {
     const systemWithdrawStep = _.get(store.state, 'systemWithdraw.step');
 
-    return systemWithdrawStep > 0 && systemWithdrawStep < 5;
+    return systemWithdrawStep >= 0 && systemWithdrawStep < 5;
   },
 };

--- a/src/renderer/services/dex.js
+++ b/src/renderer/services/dex.js
@@ -2577,4 +2577,9 @@ export default {
       }
     });
   },
+  isSystemAssetWithdrawInProgress() {
+    const systemWithdrawStep = _.get(store.state, 'systemWithdraw.step');
+
+    return systemWithdrawStep > 0 && systemWithdrawStep < 5;
+  },
 };


### PR DESCRIPTION
## Ticket
* N/A

## Changes
* Fix Dex: TestNet demo confirmation text to reflect current state of MainNet. 
* Update 'Withdraw System Asset' to only allow one in-progress at a time. 
* Disable network switch when system asset withdraw 'in-progress'

## Screenshots

## Code Coverage
