### PR TITLE
DEX: Fix trade buckets API URL( use '&' instead of '?')

### DIFF
--- a/src/renderer/services/dex.js
+++ b/src/renderer/services/dex.js
@@ -266,7 +266,7 @@ export default {
     return new Promise((resolve, reject) => {
       try {
         const currentNetwork = network.getSelectedNetwork();
-        axios.get(`${currentNetwork.aph}/trades/bucketed/${marketName}?binSize=${binSize}?binCount=1440`)
+        axios.get(`${currentNetwork.aph}/trades/bucketed/${marketName}?binSize=${binSize}&binCount=1440`)
           .then((res) => {
             resolve(res.data.buckets);
           })


### PR DESCRIPTION
## Ticket
* N/A

## Changes
* Fix query string syntax for buckets API request.

## Screenshots

## Code Coverage
