### PR TITLE
Updates to DEX Market Selector and Claim GAS button.

### DIFF
--- a/src/renderer/components/Holding.vue
+++ b/src/renderer/components/Holding.vue
@@ -10,6 +10,7 @@
     <div class="center" v-if="canBeRemoved">
       <div class="remove" @click="handleOnRemove">{{$t('remove')}}</div>
     </div>
+    <claim-gas-button v-if="this.holding.symbol === 'NEO'"></claim-gas-button>
     <div class="right">
       <div class="balance">
         <div class="amount" :title="balanceToolTip">
@@ -24,7 +25,12 @@
 </template>
 
 <script>
+import ClaimGasButton from './dashboard/ClaimGasButton';
+
 export default {
+  components: {
+    ClaimGasButton,
+  },
   computed: {
     canBeRemoved() {
       return this.holding.canRemove;

--- a/src/renderer/components/assets/AssetTable.vue
+++ b/src/renderer/components/assets/AssetTable.vue
@@ -17,6 +17,16 @@ import { mapGetters } from 'vuex';
 import { BigNumber } from 'bignumber.js';
 
 export default {
+  beforeDestroy() {
+    clearInterval(this.loadTransactionsIntervalId);
+  },
+  beforeMount() {
+    this.loadTransactions();
+
+    this.loadTransactionsIntervalId = setInterval(() => {
+      this.loadTransactions();
+    }, this.$constants.intervals.TRANSACTIONS_POLLING);
+  },
   computed: {
     filteredHoldings() {
       const searchBy = this.searchBy.toLowerCase();
@@ -52,12 +62,17 @@ export default {
   data() {
     return {
       searchBy: '',
+      loadTransactionsIntervalId: null,
     };
   },
 
   methods: {
     loadHoldings() {
       this.$store.dispatch('fetchHoldings');
+    },
+
+    loadTransactions() {
+      this.$store.dispatch('fetchRecentTransactions');
     },
 
     remove(holding) {

--- a/src/renderer/components/dashboard/ClaimGasButton.vue
+++ b/src/renderer/components/dashboard/ClaimGasButton.vue
@@ -9,15 +9,20 @@ export default {
       return this.$isPending('claimGas') ? this.$t('claiming')
         : this.$t('claimGas', { gas: this.formattedAmountToClaim });
     },
-
     formattedAmountToClaim() {
-      return this.$formatNumber(this.$store.state.statsToken.availableToClaim);
+      return this.neoAsset ?
+        this.$formatNumber(this.neoAsset.availableToClaim) : 0;
+    },
+    neoAsset() {
+      return _.find(this.$store.state.holdings, { symbol: 'NEO' });
     },
   },
 
   methods: {
     claim() {
-      this.$store.dispatch('claimGas');
+      if (this.neoAsset.availableToClaim > 0) {
+        this.$store.dispatch('claimGas');
+      }
     },
   },
 };
@@ -35,6 +40,7 @@ export default {
   height: auto;
   padding: $space-xs $space;
   text-transform: uppercase;
+  width: auto;
 
   &:hover {
     background-color: $purple;

--- a/src/renderer/components/dashboard/TokenStats.vue
+++ b/src/renderer/components/dashboard/TokenStats.vue
@@ -13,7 +13,6 @@
         <div class="name">{{ $store.state.statsToken.name }}</div>
         <div class="amount">{{ formattedAmount }}<span class="currency">{{ $store.state.statsToken.symbol }}</span></div>
         <div class="value">{{ $formatMoney($store.state.statsToken.totalValue, null, `${$store.state.currencySymbol }0.00`) }}<span class="currency">{{ $store.state.currency }}</span></div>
-        <claim-gas-button v-if="$store.state.statsToken.availableToClaim"></claim-gas-button>
       </div>
     </div>
     <div class="footer">
@@ -145,10 +144,6 @@ export default {
         }
       }
 
-      .claim-gas-button {
-        margin-top: $space;
-      }
-
       &.small {
         .amount {
           font-size: toRem(22px);
@@ -181,10 +176,6 @@ export default {
           .currency {
             font-size: toRem(16px);
           }
-        }
-
-        .claim-gas-button {
-          margin-top: $space-sm;
         }
       }
     }

--- a/src/renderer/components/dex/MarketMegaSelector.vue
+++ b/src/renderer/components/dex/MarketMegaSelector.vue
@@ -18,7 +18,7 @@
         </div>
         <div class="body">
           <div @click="market.marketName !== $store.state.currentMarket.marketName ? selectMarket(market) : null" 
-            :class="['row', {selected: $store.state.currentMarket && market.marketName === $store.state.currentMarket.marketName }]"
+            :class="['row tiled', {selected: $store.state.currentMarket && market.marketName === $store.state.currentMarket.marketName }]"
                v-for="market in filteredMarkets" :key="market.marketName">
             <div class="cell flex-horizontal">
               <div class="cell">{{ market.quoteCurrency }}</div>
@@ -251,11 +251,15 @@ export default {
 
           &:hover,
           &.selected {
-            background: $background;
+            background: $background !important;
           }
 
           &.selected {
             cursor: default;
+          }
+
+          &:nth-child(even) {
+            background: #fdfdfc;
           }
         }
       }
@@ -307,7 +311,7 @@ export default {
 
             &:hover,
             &.selected {
-              background: $purple;
+              background: $purple !important;
               color: #FFF;
             }
 
@@ -315,6 +319,10 @@ export default {
               border-bottom-left-radius: $border-radius;
               border-bottom-right-radius: $border-radius;
               border-bottom:0;
+            }
+
+            &:nth-child(even) {
+              background: $background-night-light;
             }
           }
         }

--- a/src/renderer/components/dex/MarketMegaSelector.vue
+++ b/src/renderer/components/dex/MarketMegaSelector.vue
@@ -18,7 +18,7 @@
         </div>
         <div class="body">
           <div @click="market.marketName !== $store.state.currentMarket.marketName ? selectMarket(market) : null" 
-            :class="['row tiled', {selected: $store.state.currentMarket && market.marketName === $store.state.currentMarket.marketName }]"
+            :class="['row', {selected: $store.state.currentMarket && market.marketName === $store.state.currentMarket.marketName }]"
                v-for="market in filteredMarkets" :key="market.marketName">
             <div class="cell flex-horizontal">
               <div class="cell">{{ market.quoteCurrency }}</div>

--- a/src/renderer/components/dex/MarketSelection.vue
+++ b/src/renderer/components/dex/MarketSelection.vue
@@ -11,7 +11,10 @@
         <div class="day-values">
           <div class="row">
             <div class="label">{{$t('vol')}}</div>
-            <div class="value">{{ tickerData.quoteVolume }}</div>
+            <div class="value">
+              <div>{{ $formatMoney(tickerData.quoteVolume * basePriceConverted) }}</div>
+              <div class="quote-volume">{{ $abbreviateNumber(tickerData.quoteVolume) }} ({{ storeStateCurrentMarket.baseCurrency }})</div>
+            </div>
           </div>
           <div class="row">
             <div class="label">{{$t('OPEN')}}</div>
@@ -32,7 +35,7 @@
             {{ $formatTokenAmount(close24Hour) }}
           </div>
           <div class="base-price-converted">
-            {{ $formatMoney(close24Hour * baseCurrencyUnitPrice) }}
+            {{ $formatMoney(basePriceConverted) }}
           </div>
           <span class="label">{{ $t('change24H') }} ({{ $store.state.currentMarket ? $store.state.currentMarket.quoteCurrency : '' }})</span>
           <div :class="['change', {decrease: change24Hour < 0, increase: change24Hour > 0 }]">
@@ -56,6 +59,9 @@ export default {
   },
 
   computed: {
+    basePriceConverted() {
+      return this.close24Hour * this.baseCurrencyUnitPrice;
+    },
     storeStateCurrentMarket() {
       return this.$store.state.currentMarket;
     },
@@ -123,7 +129,7 @@ export default {
     }
 
     .token-details {
-      flex: none
+      flex: none;
     }
 
     .row {
@@ -132,7 +138,6 @@ export default {
 
       .label {
         @extend %small-uppercase-grey-label-dark;
-
         flex: 2;
       }
 
@@ -140,9 +145,11 @@ export default {
         flex: 3;
         font-family: GilroySemibold;
         font-size: toRem(12px);
+        white-space: nowrap;
       }
 
-      &.row {
+      &.row, 
+      .quote-volume {
         margin-top: $space-sm;
       }
     }

--- a/src/renderer/components/dex/MarketSelection.vue
+++ b/src/renderer/components/dex/MarketSelection.vue
@@ -74,7 +74,8 @@ export default {
         / this.tickerData.open24hr) * 10000) / 100;
     },
     change24Hour() {
-      if (this.$isPending('fetchTradeHistory')) {
+      if (this.$isPending('fetchTradeHistory') &&
+        !_.get(this.$store.state.requests, 'fetchTradeHistory').isSilent) {
         return 0;
       }
 

--- a/src/renderer/components/dex/OrderForm.vue
+++ b/src/renderer/components/dex/OrderForm.vue
@@ -793,6 +793,7 @@ export default {
     }
     .aph-input {
       border-color: $background;
+      margin-top: $space-sm;
 
       &.focused {
         .border {
@@ -890,10 +891,6 @@ export default {
           border-bottom: toRem(2px) solid $purple-hover;
         }
       }
-    }
-
-    .quantity {
-      margin-top: $space-sm;
     }
   }
 

--- a/src/renderer/services/formatting.js
+++ b/src/renderer/services/formatting.js
@@ -59,7 +59,7 @@ export default {
     return moment.unix(timestamp).format(formats.DATE_SHORT);
   },
 
-  formatMoney(value, symbol, defaultValue = 'N/A') {
+  formatMoney(value, symbol, defaultValue = 'N/A', abbreviate = false) {
     if (nullOrUndefined(value)) {
       return defaultValue;
     }
@@ -69,7 +69,12 @@ export default {
     if (val.isLessThan(1) && !val.isZero()) {
       precision = 4;
     }
-    return accounting.formatMoney(val, symbol || settings.getCurrencySymbol(), precision);
+
+    const displaySymbol = symbol || settings.getCurrencySymbol();
+
+    return abbreviate ?
+      numeral(formatNumberBase(value, formats.WHOLE_NUMBER)).format(`${displaySymbol}0.0a`) :
+      accounting.formatMoney(val, displaySymbol, precision);
   },
 
   formatMoneyWithoutCents(value, symbol, defaultValue = 'N/A') {


### PR DESCRIPTION
* Updated 'VOL' data field to include $$ volume and abbreviated Quote volume
![image](https://user-images.githubusercontent.com/10226077/48321169-caef1780-e5dd-11e8-8dc5-1cc260e335d1.png)

* Update market selection menu to include 3rd column 'VOL {baseAsset}). Abbreviate both column values to accommodate larger values. 
* Stripe the rows

Night Menu 
![image](https://user-images.githubusercontent.com/10226077/48321197-fbcf4c80-e5dd-11e8-9e62-6e6c0dd55fc9.png)

Day Menu
![image](https://user-images.githubusercontent.com/10226077/48321243-48b32300-e5de-11e8-9c44-63cc062b30fd.png)

* Claim GAS button moved to 'Holdings' component and shown at all times. 
* Disable 'Claim' action when available to claim = 0. 

Dashboard
![image](https://user-images.githubusercontent.com/10226077/48321280-7009f000-e5de-11e8-91c7-2303792e8e97.png)

Assets
![image](https://user-images.githubusercontent.com/10226077/48321287-8152fc80-e5de-11e8-9669-6e6e33741576.png)




